### PR TITLE
refactor(db): migrate to async libsql backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - **Typecheck**: tsgo (native TypeScript)
 - **Release**: changelogen
 - **Package manager**: pnpm
-- **Database**: SQLite via better-sqlite3 + drizzle-orm
+- **Database**: SQLite via libsql + drizzle-orm
 - **Schema migrations**: drizzle-kit
 
 ## Scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-
 ## v0.0.2
-
 
 ### 🏡 Chore
 
@@ -11,4 +9,3 @@
 ### ❤️ Contributors
 
 - Ori ([@oritwoen](https://github.com/oritwoen))
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pnpm add ai zod
 ```ts
 import { createObsxa } from "obsxa";
 
-const obsxa = createObsxa({ db: "./research.db" });
+const obsxa = await createObsxa({ db: "./research.db" });
 
 // Create a project
 obsxa.project.add({ id: "sensor-data", name: "Sensor Analysis" });
@@ -109,7 +109,7 @@ const isolated = obsxa.analysis.isolated("sensor-data"); // observations with no
 const convergent = obsxa.analysis.convergent("sensor-data"); // confirmed by multiple sources
 const stats = obsxa.analysis.stats("sensor-data"); // project-level summary
 
-obsxa.close();
+await obsxa.close();
 ```
 
 ### CLI
@@ -415,7 +415,7 @@ pnpm test:run    # vitest --run
 You can configure startup behavior:
 
 ```ts
-createObsxa({
+await createObsxa({
   db: "./obsxa.db",
   autoMigrate: true, // default
   autoBackup: true, // default

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ import { createObsxa } from "obsxa";
 const obsxa = await createObsxa({ db: "./research.db" });
 
 // Create a project
-obsxa.project.add({ id: "sensor-data", name: "Sensor Analysis" });
+await obsxa.project.add({ id: "sensor-data", name: "Sensor Analysis" });
 
 // Record observations
-const o1 = obsxa.observation.add({
+const o1 = await obsxa.observation.add({
   projectId: "sensor-data",
   title: "Temperature spike at station 7",
   description: "Unusual 3σ deviation from baseline",
@@ -73,7 +73,7 @@ const o1 = obsxa.observation.add({
   context: JSON.stringify({ instrument: "DHT22", location: "lab-3", ambient: 21.0 }),
 });
 
-const o2 = obsxa.observation.add({
+const o2 = await obsxa.observation.add({
   projectId: "sensor-data",
   title: "Humidity drop correlates with spike",
   source: "station-7-humidity",
@@ -82,32 +82,32 @@ const o2 = obsxa.observation.add({
 });
 
 // Seen again — increment frequency
-obsxa.observation.incrementFrequency(o1.id);
+await obsxa.observation.incrementFrequency(o1.id);
 
 // Connect related observations
-obsxa.relation.add({
+await obsxa.relation.add({
   fromObservationId: o2.id,
   toObservationId: o1.id,
   type: "supports",
 });
 
 // Group them
-const cluster = obsxa.cluster.add({
+const cluster = await obsxa.cluster.add({
   projectId: "sensor-data",
   name: "Station 7 anomalies",
 });
-obsxa.cluster.addMember(cluster.id, o1.id);
-obsxa.cluster.addMember(cluster.id, o2.id);
+await obsxa.cluster.addMember(cluster.id, o1.id);
+await obsxa.cluster.addMember(cluster.id, o2.id);
 
 // Promote to hypothesis when ready
-obsxa.observation.promote(o1.id, "hypxa:sensor-data:1");
+await obsxa.observation.promote(o1.id, "hypxa:sensor-data:1");
 
 // Analysis
-const frequent = obsxa.analysis.frequent("sensor-data"); // observations seen multiple times
-const unpromoted = obsxa.analysis.unpromoted("sensor-data"); // candidates for hypotheses
-const isolated = obsxa.analysis.isolated("sensor-data"); // observations with no relations
-const convergent = obsxa.analysis.convergent("sensor-data"); // confirmed by multiple sources
-const stats = obsxa.analysis.stats("sensor-data"); // project-level summary
+const frequent = await obsxa.analysis.frequent("sensor-data"); // observations seen multiple times
+const unpromoted = await obsxa.analysis.unpromoted("sensor-data"); // candidates for hypotheses
+const isolated = await obsxa.analysis.isolated("sensor-data"); // observations with no relations
+const convergent = await obsxa.analysis.convergent("sensor-data"); // confirmed by multiple sources
+const stats = await obsxa.analysis.stats("sensor-data"); // project-level summary
 
 await obsxa.close();
 ```
@@ -415,12 +415,13 @@ pnpm test:run    # vitest --run
 You can configure startup behavior:
 
 ```ts
-await createObsxa({
+const obsxa = await createObsxa({
   db: "./obsxa.db",
   autoMigrate: true, // default
   autoBackup: true, // default
   backupDir: "./backups",
 });
+await obsxa.close();
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -44,14 +44,13 @@
     "release": "pnpm test:run && pnpm build && changelogen --release --push"
   },
   "dependencies": {
+    "@libsql/client": "^0.17.0",
     "@toon-format/toon": "^2.1.0",
-    "better-sqlite3": "^11.0.0",
     "citty": "^0.2.1",
     "consola": "^3.4.0",
     "drizzle-orm": "^0.44.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^25.3.0",
     "@typescript/native-preview": "latest",
     "ai": "^6.0.116",
@@ -82,7 +81,6 @@
   "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3",
       "esbuild"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@libsql/client':
+        specifier: ^0.17.0
+        version: 0.17.0
       '@toon-format/toon':
         specifier: ^2.1.0
         version: 2.1.0
-      better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
       citty:
         specifier: ^0.2.1
         version: 0.2.1
@@ -22,11 +22,8 @@ importers:
         version: 3.4.2
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
+        version: 0.44.7(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.11
-        version: 7.6.13
       '@types/node':
         specifier: ^25.3.0
         version: 25.4.0
@@ -577,8 +574,68 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@libsql/client@0.17.0':
+    resolution: {integrity: sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==}
+
+  '@libsql/core@0.17.0':
+    resolution: {integrity: sha512-hnZRnJHiS+nrhHKLGYPoJbc78FE903MSDrFJTbftxo+e52X+E0Y0fHOCVYsKWcg6XgB7BbJYUrz/xEkVTSaipw==}
+
+  '@libsql/darwin-arm64@0.5.22':
+    resolution: {integrity: sha512-4B8ZlX3nIDPndfct7GNe0nI3Yw6ibocEicWdC4fvQbSs/jdq/RC2oCsoJxJ4NzXkvktX70C1J4FcmmoBy069UA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.22':
+    resolution: {integrity: sha512-ny2HYWt6lFSIdNFzUFIJ04uiW6finXfMNJ7wypkAD8Pqdm6nAByO+Fdqu8t7sD0sqJGeUCiOg480icjyQ2/8VA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.9.0':
+    resolution: {integrity: sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.22':
+    resolution: {integrity: sha512-3Uo3SoDPJe/zBnyZKosziRGtszXaEtv57raWrZIahtQDsjxBVjuzYQinCm9LRCJCUT5t2r5Z5nLDPJi2CwZVoA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.22':
+    resolution: {integrity: sha512-LCsXh07jvSojTNJptT9CowOzwITznD+YFGGW+1XxUr7fS+7/ydUrpDfsMX7UqTqjm7xG17eq86VkWJgHJfvpNg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.22':
+    resolution: {integrity: sha512-KSdnOMy88c9mpOFKUEzPskSaF3VLflfSUCBwas/pn1/sV3pEhtMF6H8VUCd2rsedwoukeeCSEONqX7LLnQwRMA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.22':
+    resolution: {integrity: sha512-mCHSMAsDTLK5YH//lcV3eFEgiR23Ym0U9oEvgZA0667gqRZg/2px+7LshDvErEKv2XZ8ixzw3p1IrBzLQHGSsw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.22':
+    resolution: {integrity: sha512-kNBHaIkSg78Y4BqAdgjcR2mBilZXs4HYkAmi58J+4GRwDQZh5fIUWbnQvB9f95DkWUIGVeenqLRFY2pcTmlsew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.22':
+    resolution: {integrity: sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.22':
+    resolution: {integrity: sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1094,6 +1151,9 @@ packages:
   '@types/node@25.4.0':
     resolution: {integrity: sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260310.1':
     resolution: {integrity: sha512-mzMXa3AIcEh3OKkuVYf/bvb8D6wsJ/kn1KLwBGb4C1NCak102spy1Bio1myrTMyjb/R+hRM7gom+KZ/5IHJvIg==}
     cpu: [arm64]
@@ -1271,6 +1331,13 @@ packages:
   convert-gitmoji@0.1.5:
     resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1305,6 +1372,10 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1472,8 +1543,16 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1520,6 +1599,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1527,6 +1609,11 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  libsql@0.5.22:
+    resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -1566,8 +1653,26 @@ packages:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
@@ -1642,6 +1747,9 @@ packages:
   pretty-bytes@7.1.0:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1797,6 +1905,9 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1891,6 +2002,16 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1898,6 +2019,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
@@ -2212,12 +2345,76 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.0':
+    dependencies:
+      '@libsql/core': 0.17.0
+      '@libsql/hrana-client': 0.9.0
+      js-base64: 3.7.8
+      libsql: 0.5.22
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/core@0.17.0':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@libsql/darwin-arm64@0.5.22':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.22':
+    optional: true
+
+  '@libsql/hrana-client@0.9.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      cross-fetch: 4.1.0
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.22':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.22':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.22':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.22':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -2473,6 +2670,7 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.4.0
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2488,6 +2686,10 @@ snapshots:
   '@types/node@25.4.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.4.0
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260310.1':
     optional: true
@@ -2579,16 +2781,19 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
-  base64-js@1.5.1: {}
+  base64-js@1.5.1:
+    optional: true
 
   better-sqlite3@11.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
 
   birpc@4.0.0: {}
 
@@ -2597,6 +2802,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   buffer-from@1.1.2: {}
 
@@ -2604,6 +2810,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -2662,7 +2869,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   citty@0.1.6:
     dependencies:
@@ -2678,6 +2886,14 @@ snapshots:
 
   convert-gitmoji@0.1.5: {}
 
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2685,8 +2901,10 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   default-browser-id@5.0.1: {}
 
@@ -2701,7 +2919,10 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-libc@2.1.2: {}
+  detect-libc@2.0.2: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   dotenv@17.3.1: {}
 
@@ -2714,8 +2935,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
+  drizzle-orm@0.44.7(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
     optionalDependencies:
+      '@libsql/client': 0.17.0
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 11.10.0
@@ -2725,6 +2947,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   es-module-lexer@1.7.0: {}
 
@@ -2824,7 +3047,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -2834,9 +3058,20 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  file-uri-to-path@1.0.0: {}
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
-  fs-constants@1.0.0: {}
+  file-uri-to-path@1.0.0:
+    optional: true
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fs-constants@1.0.0:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -2854,13 +3089,17 @@ snapshots:
       nypm: 0.6.5
       pathe: 2.0.3
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
-  inherits@2.0.4: {}
+  inherits@2.0.4:
+    optional: true
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   is-docker@3.0.0: {}
 
@@ -2874,9 +3113,26 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-base64@3.7.8: {}
+
   jsesc@3.1.0: {}
 
   json-schema@0.4.0: {}
+
+  libsql@0.5.22:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.22
+      '@libsql/darwin-x64': 0.5.22
+      '@libsql/linux-arm-gnueabihf': 0.5.22
+      '@libsql/linux-arm-musleabihf': 0.5.22
+      '@libsql/linux-arm64-gnu': 0.5.22
+      '@libsql/linux-arm64-musl': 0.5.22
+      '@libsql/linux-x64-gnu': 0.5.22
+      '@libsql/linux-x64-musl': 0.5.22
+      '@libsql/win32-x64-msvc': 0.5.22
 
   lodash@4.17.23: {}
 
@@ -2884,11 +3140,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
-  minimist@1.2.8: {}
+  minimist@1.2.8:
+    optional: true
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   moment@2.30.1: {}
 
@@ -2898,13 +3157,27 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.4
+    optional: true
+
+  node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   nypm@0.6.5:
     dependencies:
@@ -2952,6 +3225,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   open@10.2.0:
     dependencies:
@@ -3042,13 +3316,17 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   pretty-bytes@7.1.0: {}
+
+  promise-limit@2.7.0: {}
 
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   rc9@2.1.2:
     dependencies:
@@ -3066,12 +3344,14 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readdirp@5.0.0: {}
 
@@ -3163,7 +3443,8 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
-  safe-buffer@5.2.1: {}
+  safe-buffer@5.2.1:
+    optional: true
 
   scule@1.3.0: {}
 
@@ -3171,13 +3452,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -3222,8 +3505,10 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   tar-fs@2.1.4:
     dependencies:
@@ -3231,6 +3516,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -3239,6 +3525,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tinybench@2.9.0: {}
 
@@ -3253,12 +3540,15 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tr46@0.0.3: {}
+
   tslib@2.8.1:
     optional: true
 
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   typescript@5.9.3: {}
 
@@ -3266,7 +3556,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  util-deprecate@1.0.2: {}
+  util-deprecate@1.0.2:
+    optional: true
 
   vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1):
     dependencies:
@@ -3319,12 +3610,24 @@ snapshots:
       - tsx
       - yaml
 
+  web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
+
+  ws@8.19.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -12,7 +12,7 @@ function sanitizeDbPath(path?: string): string {
   return dbPath;
 }
 
-function getOrCreate(dbPath?: string): ObsxaInstance {
+async function getOrCreate(dbPath?: string): Promise<ObsxaInstance> {
   return createObsxa({ db: sanitizeDbPath(dbPath) });
 }
 
@@ -164,21 +164,21 @@ export const observationTool = tool({
     }),
   ]),
   execute: async (input) => {
-    const obsxa = getOrCreate(input.db);
+    const obsxa = await getOrCreate(input.db);
     try {
       switch (input.operation) {
         case "add":
-          return obsxa.observation.add(input);
+          return await obsxa.observation.add(input);
         case "get":
-          return obsxa.observation.get(input.id);
+          return await obsxa.observation.get(input.id);
         case "list":
-          return obsxa.observation.list(input.projectId, {
+          return await obsxa.observation.list(input.projectId, {
             status: input.status,
             type: input.type,
             sourceType: input.sourceType,
           });
         case "update":
-          return obsxa.observation.update(input.id, {
+          return await obsxa.observation.update(input.id, {
             title: input.title,
             description: input.description,
             type: input.type,
@@ -198,28 +198,28 @@ export const observationTool = tool({
             reproducibilityHint: input.reproducibilityHint,
           });
         case "transitions":
-          return obsxa.observation.transitions(input.id);
+          return await obsxa.observation.transitions(input.id);
         case "edits":
-          return obsxa.observation.edits(input.id);
+          return await obsxa.observation.edits(input.id);
         case "dismiss":
-          return obsxa.observation.dismiss(input.id, {
+          return await obsxa.observation.dismiss(input.id, {
             reasonCode: input.reasonCode,
             reasonNote: input.reasonNote,
           });
         case "archive":
-          return obsxa.observation.archive(input.id, {
+          return await obsxa.observation.archive(input.id, {
             reasonCode: input.reasonCode,
             reasonNote: input.reasonNote,
           });
         case "bump":
-          return obsxa.observation.incrementFrequency(input.id);
+          return await obsxa.observation.incrementFrequency(input.id);
         case "import":
-          return obsxa.observation.addMany(input.records);
+          return await obsxa.observation.addMany(input.records);
         case "batchUpdate":
-          return obsxa.observation.updateMany(input.records);
+          return await obsxa.observation.updateMany(input.records);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -251,16 +251,16 @@ export const relationTool = tool({
     }),
   ]),
   execute: async (input) => {
-    const obsxa = getOrCreate(input.db);
+    const obsxa = await getOrCreate(input.db);
     try {
       switch (input.operation) {
         case "add":
-          return obsxa.relation.add(input);
+          return await obsxa.relation.add(input);
         case "list":
-          return obsxa.relation.list(input.observationId);
+          return await obsxa.relation.list(input.observationId);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -289,24 +289,24 @@ export const clusterTool = tool({
     }),
   ]),
   execute: async (input) => {
-    const obsxa = getOrCreate(input.db);
+    const obsxa = await getOrCreate(input.db);
     try {
       switch (input.operation) {
         case "add":
-          return obsxa.cluster.add({
+          return await obsxa.cluster.add({
             projectId: input.projectId,
             name: input.name,
             description: input.description,
           });
         case "list":
-          return obsxa.cluster.list(input.projectId);
+          return await obsxa.cluster.list(input.projectId);
         case "addMember":
-          return obsxa.cluster.addMember(input.clusterId, input.observationId);
+          return await obsxa.cluster.addMember(input.clusterId, input.observationId);
         case "listMembers":
-          return obsxa.cluster.listMembers(input.clusterId);
+          return await obsxa.cluster.listMembers(input.clusterId);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -320,11 +320,11 @@ export const searchTool = tool({
     limit: z.number().optional(),
   }),
   execute: async ({ db, query, projectId, limit }) => {
-    const obsxa = getOrCreate(db);
+    const obsxa = await getOrCreate(db);
     try {
-      return obsxa.search.search(query, projectId, limit);
+      return await obsxa.search.search(query, projectId, limit);
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -368,26 +368,26 @@ export const analysisTool = tool({
     }),
   ]),
   execute: async (input) => {
-    const obsxa = getOrCreate(input.db);
+    const obsxa = await getOrCreate(input.db);
     try {
       switch (input.operation) {
         case "stats":
-          return obsxa.analysis.stats(input.projectId);
+          return await obsxa.analysis.stats(input.projectId);
         case "frequent":
-          return obsxa.analysis.frequent(input.projectId);
+          return await obsxa.analysis.frequent(input.projectId);
         case "isolated":
-          return obsxa.analysis.isolated(input.projectId);
+          return await obsxa.analysis.isolated(input.projectId);
         case "convergent":
-          return obsxa.analysis.convergent(input.projectId);
+          return await obsxa.analysis.convergent(input.projectId);
         case "promoted":
-          return obsxa.analysis.promoted(input.projectId);
+          return await obsxa.analysis.promoted(input.projectId);
         case "unpromoted":
-          return obsxa.analysis.unpromoted(input.projectId);
+          return await obsxa.analysis.unpromoted(input.projectId);
         case "triage":
-          return obsxa.analysis.triage(input.projectId, input.limit, input.sort);
+          return await obsxa.analysis.triage(input.projectId, input.limit, input.sort);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -400,11 +400,11 @@ export const promoteTool = tool({
     hypothesisRef: z.string(),
   }),
   execute: async ({ db, observationId, hypothesisRef }) => {
-    const obsxa = getOrCreate(db);
+    const obsxa = await getOrCreate(db);
     try {
-      return obsxa.observation.promote(observationId, hypothesisRef);
+      return await obsxa.observation.promote(observationId, hypothesisRef);
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });
@@ -454,17 +454,17 @@ export const dedupTool = tool({
     }),
   ]),
   execute: async (input) => {
-    const obsxa = getOrCreate(input.db);
+    const obsxa = await getOrCreate(input.db);
     try {
       switch (input.operation) {
         case "scan":
-          return obsxa.dedup.scan(input.projectId, input.threshold);
+          return await obsxa.dedup.scan(input.projectId, input.threshold);
         case "candidates":
-          return obsxa.dedup.candidates(input.projectId, input.status);
+          return await obsxa.dedup.candidates(input.projectId, input.status);
         case "review":
-          return obsxa.dedup.review(input.candidateId, input.status, input.reason);
+          return await obsxa.dedup.review(input.candidateId, input.status, input.reason);
         case "merge":
-          return obsxa.dedup.merge(input.primaryObservationId, input.duplicateObservationId, {
+          return await obsxa.dedup.merge(input.primaryObservationId, input.duplicateObservationId, {
             confidenceStrategy: input.confidenceStrategy,
             relationType: input.relationType,
             relationConfidence: input.relationConfidence,
@@ -473,7 +473,7 @@ export const dedupTool = tool({
           });
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/_db.ts
+++ b/src/commands/_db.ts
@@ -8,7 +8,7 @@ export const dbArgs = {
   toon: { type: "boolean" as const, description: "Output as TOON", default: false },
 };
 
-export function open(dbPath: string) {
+export async function open(dbPath: string) {
   return createObsxa({ db: dbPath });
 }
 

--- a/src/commands/cluster.ts
+++ b/src/commands/cluster.ts
@@ -15,10 +15,10 @@ export default defineCommand({
             name: { type: "string", required: true, description: "Cluster name" },
             description: { type: "string", description: "Cluster description" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const cluster = obsxa.cluster.add({
+              const cluster = await obsxa.cluster.add({
                 projectId: args.project,
                 name: args.name,
                 description: args.description,
@@ -26,7 +26,7 @@ export default defineCommand({
               if (args.toon || args.json) return output(cluster, args.toon);
               consola.success(`Cluster #${cluster.id} created: ${cluster.name}`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -39,10 +39,10 @@ export default defineCommand({
             ...dbArgs,
             project: { type: "string", required: true, description: "Project ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.cluster.list(args.project);
+              const rows = await obsxa.cluster.list(args.project);
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No clusters found.");
               for (const row of rows) {
@@ -51,7 +51,7 @@ export default defineCommand({
                 );
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -65,17 +65,17 @@ export default defineCommand({
             cluster: { type: "string", required: true, description: "Cluster ID" },
             observation: { type: "string", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const member = obsxa.cluster.addMember(
+              const member = await obsxa.cluster.addMember(
                 parseId(args.cluster, "cluster"),
                 parseId(args.observation, "observation"),
               );
               if (args.toon || args.json) return output(member, args.toon);
               consola.success(`Member #${member.id} added to cluster #${member.clusterId}`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -88,17 +88,17 @@ export default defineCommand({
             ...dbArgs,
             cluster: { type: "string", required: true, description: "Cluster ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.cluster.listMembers(parseId(args.cluster, "cluster"));
+              const rows = await obsxa.cluster.listMembers(parseId(args.cluster, "cluster"));
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No cluster members found.");
               for (const row of rows) {
                 consola.log(`#${row.id} [${row.status}] ${row.title}`);
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),

--- a/src/commands/dedup.ts
+++ b/src/commands/dedup.ts
@@ -26,22 +26,22 @@ export default defineCommand({
               description: "Near-duplicate threshold (0..1, default 0.72)",
             },
           },
-          run({ args }) {
+          async run({ args }) {
             const threshold = args.threshold ? Number.parseFloat(args.threshold) : 0.72;
             if (Number.isNaN(threshold) || threshold < 0 || threshold > 1) {
               consola.error("Threshold must be a number from 0 to 1");
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.dedup.scan(args.project, threshold);
+              const result = await obsxa.dedup.scan(args.project, threshold);
               if (args.toon || args.json) return output(result, args.toon);
               consola.success(
                 `Scanned ${result.checkedPairs} pairs, found ${result.candidates.length} candidates`,
               );
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -56,7 +56,7 @@ export default defineCommand({
             project: { type: "string", required: true, description: "Project ID" },
             status: { type: "string", description: "open|resolved|dismissed|all (default: open)" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (
               args.status &&
               args.status !== "all" &&
@@ -69,9 +69,9 @@ export default defineCommand({
             }
 
             const status = (args.status ?? "open") as DuplicateCandidateStatus | "all";
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.dedup.candidates(args.project, status);
+              const rows = await obsxa.dedup.candidates(args.project, status);
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No duplicate candidates found.");
               for (const row of rows) {
@@ -80,7 +80,7 @@ export default defineCommand({
                 );
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -99,7 +99,7 @@ export default defineCommand({
             status: { type: "string", required: true, description: "open|resolved|dismissed" },
             reason: { type: "string", required: true, description: "Decision reason" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (!statuses.includes(args.status as DuplicateCandidateStatus)) {
               consola.error(
                 `Invalid status "${args.status}". Must be one of: ${statuses.join(", ")}`,
@@ -109,9 +109,9 @@ export default defineCommand({
 
             const id = parseId(args.id, "id");
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.dedup.review(
+              const result = await obsxa.dedup.review(
                 id,
                 args.status as DuplicateCandidateStatus,
                 args.reason,
@@ -121,7 +121,7 @@ export default defineCommand({
                 `Candidate #${result.candidate.id} moved to ${result.candidate.status}`,
               );
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -157,7 +157,7 @@ export default defineCommand({
               description: "primary|duplicate|concat (default: concat)",
             },
           },
-          run({ args }) {
+          async run({ args }) {
             if (
               args.strategy &&
               !confidenceStrategies.includes(args.strategy as MergeConfidenceStrategy)
@@ -204,9 +204,9 @@ export default defineCommand({
               }
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.dedup.merge(primaryId, duplicateId, {
+              const result = await obsxa.dedup.merge(primaryId, duplicateId, {
                 confidenceStrategy: args.strategy as MergeConfidenceStrategy | undefined,
                 relationType: args["relation-type"] as ObservationRelationType | undefined,
                 relationConfidence,
@@ -222,7 +222,7 @@ export default defineCommand({
                 `Merged #${result.merged.id} into #${result.primary.id}; frequency=${result.primary.frequency}`,
               );
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),

--- a/src/commands/frequent.ts
+++ b/src/commands/frequent.ts
@@ -8,17 +8,17 @@ export default defineCommand({
     ...dbArgs,
     projectId: { type: "positional", required: true, description: "Project ID" },
   },
-  run({ args }) {
-    const obsxa = open(args.db);
+  async run({ args }) {
+    const obsxa = await open(args.db);
     try {
-      const rows = obsxa.analysis.frequent(args.projectId);
+      const rows = await obsxa.analysis.frequent(args.projectId);
       if (args.toon || args.json) return output(rows, args.toon);
       if (rows.length === 0) return consola.info("No frequent observations found.");
       for (const row of rows) {
         consola.log(`#${row.id} f=${row.frequency} ${row.title}`);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/observation.ts
+++ b/src/commands/observation.ts
@@ -93,7 +93,7 @@ export default defineCommand({
             uncertainty: { type: "string", description: "Uncertainty 0-100" },
             reproducibility: { type: "string", description: "Reproducibility hint" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (args.type && !observationTypes.includes(args.type as ObservationType)) {
               consola.error(
                 `Invalid type "${args.type}". Must be one of: ${observationTypes.join(", ")}`,
@@ -107,9 +107,9 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const observation = obsxa.observation.add({
+              const observation = await obsxa.observation.add({
                 projectId: args.project,
                 title: args.title,
                 description: args.description,
@@ -132,7 +132,7 @@ export default defineCommand({
               if (args.toon || args.json) return output(observation, args.toon);
               consola.success(`Observation #${observation.id} created: ${observation.title}`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -150,19 +150,19 @@ export default defineCommand({
               description: "Path to JSON file with observation records",
             },
           },
-          run({ args }) {
+          async run({ args }) {
             const records = readDataFile<ObservationImportRecord[]>(args.file);
             if (!Array.isArray(records)) {
               consola.error("Import file must contain a JSON array");
               process.exit(1);
             }
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const imported = obsxa.observation.addMany(records);
+              const imported = await obsxa.observation.addMany(records);
               if (args.toon || args.json) return output(imported, args.toon);
               consola.success(`Imported ${imported.length} observations`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -178,7 +178,7 @@ export default defineCommand({
             status: { type: "string", description: "Optional status filter" },
             type: { type: "string", description: "Optional type filter" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (args.status && !statuses.includes(args.status as ObservationStatus)) {
               consola.error(
                 `Invalid status "${args.status}". Must be one of: ${statuses.join(", ")}`,
@@ -192,15 +192,15 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.observation.list(args.project, {
+              const rows = await obsxa.observation.list(args.project, {
                 status: args.status as ObservationStatus | undefined,
                 type: args.type as ObservationType | undefined,
               });
               output(rows, args.toon);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -218,19 +218,19 @@ export default defineCommand({
               description: "Path to JSON file with update records",
             },
           },
-          run({ args }) {
+          async run({ args }) {
             const records = readDataFile<ObservationBatchUpdateRecord[]>(args.file);
             if (!Array.isArray(records)) {
               consola.error("Batch-update file must contain a JSON array");
               process.exit(1);
             }
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const updated = obsxa.observation.updateMany(records);
+              const updated = await obsxa.observation.updateMany(records);
               if (args.toon || args.json) return output(updated, args.toon);
               consola.success(`Updated ${updated.length} observations`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -244,10 +244,10 @@ export default defineCommand({
             ...dbArgs,
             id: { type: "positional", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const observation = obsxa.observation.get(parseId(args.id, "id"));
+              const observation = await obsxa.observation.get(parseId(args.id, "id"));
               if (!observation) {
                 consola.error(`Observation #${args.id} not found`);
                 process.exit(1);
@@ -257,7 +257,7 @@ export default defineCommand({
                 `#${observation.id} [${observation.status}] f=${observation.frequency} triage=${observation.triageScore} ${observation.title}`,
               );
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -271,17 +271,17 @@ export default defineCommand({
             ...dbArgs,
             id: { type: "positional", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.observation.transitions(parseId(args.id, "id"));
+              const rows = await obsxa.observation.transitions(parseId(args.id, "id"));
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No transitions found.");
               for (const row of rows) {
                 consola.log(`#${row.id} ${row.fromStatus} -> ${row.toStatus} (${row.reasonCode})`);
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -295,10 +295,10 @@ export default defineCommand({
             ...dbArgs,
             id: { type: "positional", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.observation.edits(parseId(args.id, "id"));
+              const rows = await obsxa.observation.edits(parseId(args.id, "id"));
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No edits found.");
               for (const row of rows) {
@@ -307,7 +307,7 @@ export default defineCommand({
                 );
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -323,7 +323,7 @@ export default defineCommand({
             status: { type: "string", description: "Status filter" },
             type: { type: "string", description: "Type filter" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (args.status && !statuses.includes(args.status as ObservationStatus)) {
               consola.error(
                 `Invalid status "${args.status}". Must be one of: ${statuses.join(", ")}`,
@@ -337,9 +337,9 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.observation.list(args.project, {
+              const rows = await obsxa.observation.list(args.project, {
                 status: args.status as ObservationStatus | undefined,
                 type: args.type as ObservationType | undefined,
               });
@@ -351,7 +351,7 @@ export default defineCommand({
                 );
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -382,7 +382,7 @@ export default defineCommand({
             uncertainty: { type: "string", description: "Uncertainty" },
             reproducibility: { type: "string", description: "Reproducibility hint" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (args.type && !observationTypes.includes(args.type as ObservationType)) {
               consola.error(
                 `Invalid type "${args.type}". Must be one of: ${observationTypes.join(", ")}`,
@@ -396,9 +396,9 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.observation.update(parseId(args.id, "id"), {
+              const result = await obsxa.observation.update(parseId(args.id, "id"), {
                 title: args.title,
                 description: args.description,
                 type: args.type as ObservationType | undefined,
@@ -420,7 +420,7 @@ export default defineCommand({
               if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Observation #${result.id} updated`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -440,7 +440,7 @@ export default defineCommand({
             },
             note: { type: "string", description: "Optional reason note" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (!reasonCodes.includes(args.reason as ObservationStatusReasonCode)) {
               consola.error(
                 `Invalid reason "${args.reason}". Must be one of: ${reasonCodes.join(", ")}`,
@@ -448,16 +448,16 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.observation.dismiss(parseId(args.id, "id"), {
+              const result = await obsxa.observation.dismiss(parseId(args.id, "id"), {
                 reasonCode: args.reason as ObservationStatusReasonCode,
                 reasonNote: args.note,
               });
               if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Observation #${result.id} dismissed`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -477,23 +477,23 @@ export default defineCommand({
             },
             note: { type: "string", description: "Optional reason note" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (!reasonCodes.includes(args.reason as ObservationStatusReasonCode)) {
               consola.error(
                 `Invalid reason "${args.reason}". Must be one of: ${reasonCodes.join(", ")}`,
               );
               process.exit(1);
             }
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.observation.archive(parseId(args.id, "id"), {
+              const result = await obsxa.observation.archive(parseId(args.id, "id"), {
                 reasonCode: args.reason as ObservationStatusReasonCode,
                 reasonNote: args.note,
               });
               if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Observation #${result.id} archived`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -507,14 +507,14 @@ export default defineCommand({
             ...dbArgs,
             id: { type: "positional", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const result = obsxa.observation.incrementFrequency(parseId(args.id, "id"));
+              const result = await obsxa.observation.incrementFrequency(parseId(args.id, "id"));
               if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Observation #${result.id} frequency is now ${result.frequency}`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -13,10 +13,10 @@ export default defineCommand({
         name: { type: "string", required: true, description: "Project name" },
         description: { type: "string", description: "Project description" },
       },
-      run({ args }) {
-        const obsxa = open(args.db);
+      async run({ args }) {
+        const obsxa = await open(args.db);
         try {
-          const project = obsxa.project.add({
+          const project = await obsxa.project.add({
             id: args.id,
             name: args.name,
             description: args.description,
@@ -24,17 +24,17 @@ export default defineCommand({
           if (args.toon || args.json) return output(project, args.toon);
           consola.success(`Project "${project.id}" created: ${project.name}`);
         } finally {
-          obsxa.close();
+          await obsxa.close();
         }
       },
     }),
     list: defineCommand({
       meta: { name: "list", description: "List projects" },
       args: dbArgs,
-      run({ args }) {
-        const obsxa = open(args.db);
+      async run({ args }) {
+        const obsxa = await open(args.db);
         try {
-          const projects = obsxa.project.list();
+          const projects = await obsxa.project.list();
           if (args.toon || args.json) return output(projects, args.toon);
           if (projects.length === 0) return consola.info("No projects found.");
           for (const project of projects) {
@@ -43,7 +43,7 @@ export default defineCommand({
             );
           }
         } finally {
-          obsxa.close();
+          await obsxa.close();
         }
       },
     }),

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -13,11 +13,11 @@ export default defineCommand({
       description: "Hypothesis reference (e.g. hypxa:project:3)",
     },
   },
-  run({ args }) {
-    const obsxa = open(args.db);
+  async run({ args }) {
+    const obsxa = await open(args.db);
     try {
       const id = parseId(args.id, "id");
-      const observation = obsxa.observation.get(id);
+      const observation = await obsxa.observation.get(id);
       if (!observation) {
         consola.error(`Observation #${id} not found`);
         process.exit(1);
@@ -29,11 +29,11 @@ export default defineCommand({
         process.exit(1);
       }
 
-      const result = obsxa.observation.promote(id, args.ref);
+      const result = await obsxa.observation.promote(id, args.ref);
       if (args.toon || args.json) return output(result, args.toon);
       consola.success(`Observation #${result.id} promoted to ${result.promotedTo}`);
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/relation.ts
+++ b/src/commands/relation.ts
@@ -19,7 +19,7 @@ export default defineCommand({
             confidence: { type: "string", description: "Confidence 0-100 (default: 100)" },
             notes: { type: "string", description: "Optional relation notes" },
           },
-          run({ args }) {
+          async run({ args }) {
             if (!RELATION_TYPES.includes(args.type as ObservationRelationType)) {
               consola.error(
                 `Invalid type "${args.type}". Must be one of: ${RELATION_TYPES.join(", ")}`,
@@ -45,9 +45,9 @@ export default defineCommand({
               process.exit(1);
             }
 
-            const obsxa = open(args.db);
+            const obsxa = await open(args.db);
             try {
-              const relation = obsxa.relation.add({
+              const relation = await obsxa.relation.add({
                 fromObservationId: fromId,
                 toObservationId: toId,
                 type: args.type as ObservationRelationType,
@@ -57,7 +57,7 @@ export default defineCommand({
               if (args.toon || args.json) return output(relation, args.toon);
               consola.success(`Relation #${relation.id} added`);
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),
@@ -70,10 +70,10 @@ export default defineCommand({
             ...dbArgs,
             observation: { type: "string", required: true, description: "Observation ID" },
           },
-          run({ args }) {
-            const obsxa = open(args.db);
+          async run({ args }) {
+            const obsxa = await open(args.db);
             try {
-              const rows = obsxa.relation.list(parseId(args.observation, "observation"));
+              const rows = await obsxa.relation.list(parseId(args.observation, "observation"));
               if (args.toon || args.json) return output(rows, args.toon);
               if (rows.length === 0) return consola.info("No relations found.");
               for (const row of rows) {
@@ -82,7 +82,7 @@ export default defineCommand({
                 );
               }
             } finally {
-              obsxa.close();
+              await obsxa.close();
             }
           },
         }),

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -10,22 +10,22 @@ export default defineCommand({
     project: { type: "string", description: "Project ID" },
     limit: { type: "string", description: "Max results" },
   },
-  run({ args }) {
+  async run({ args }) {
     const limit = args.limit === undefined ? undefined : parseId(args.limit, "limit");
     if (limit !== undefined && limit < 1) {
       consola.error("--limit must be at least 1");
       process.exit(1);
     }
-    const obsxa = open(args.db);
+    const obsxa = await open(args.db);
     try {
-      const rows = obsxa.search.search(args.query, args.project, limit);
+      const rows = await obsxa.search.search(args.query, args.project, limit);
       if (args.toon || args.json) return output(rows, args.toon);
       if (rows.length === 0) return consola.info("No matches found.");
       for (const row of rows) {
         consola.log(`[${row.rank}] #${row.observation.id} ${row.observation.title}`);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,16 +8,16 @@ export default defineCommand({
     ...dbArgs,
     projectId: { type: "positional", required: true, description: "Project ID" },
   },
-  run({ args }) {
-    const obsxa = open(args.db);
+  async run({ args }) {
+    const obsxa = await open(args.db);
     try {
-      const stats = obsxa.analysis.stats(args.projectId);
+      const stats = await obsxa.analysis.stats(args.projectId);
       if (args.toon || args.json) return output(stats, args.toon);
       consola.log(
         `total=${stats.total} active=${stats.active} promoted=${stats.promoted} dismissed=${stats.dismissed} archived=${stats.archived} avgConfidence=${stats.avgConfidence} totalClusters=${stats.totalClusters}`,
       );
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -13,7 +13,7 @@ export default defineCommand({
     limit: { type: "string", description: "Max rows (default: 25)" },
     sort: { type: "string", description: "triage|recent (default: triage)" },
   },
-  run({ args }) {
+  async run({ args }) {
     const sort = (args.sort ?? "triage") as TriageSort;
     if (!sortModes.includes(sort)) {
       consola.error(`Invalid sort "${sort}". Must be one of: ${sortModes.join(", ")}`);
@@ -26,9 +26,9 @@ export default defineCommand({
       process.exit(1);
     }
 
-    const obsxa = open(args.db);
+    const obsxa = await open(args.db);
     try {
-      const rows = obsxa.analysis.triage(args.project, limit, sort);
+      const rows = await obsxa.analysis.triage(args.project, limit, sort);
       if (args.toon || args.json) return output(rows, args.toon);
       if (rows.length === 0) return consola.info("No active observations found.");
       for (const row of rows) {
@@ -37,7 +37,7 @@ export default defineCommand({
         );
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/commands/unpromoted.ts
+++ b/src/commands/unpromoted.ts
@@ -8,17 +8,17 @@ export default defineCommand({
     ...dbArgs,
     projectId: { type: "positional", required: true, description: "Project ID" },
   },
-  run({ args }) {
-    const obsxa = open(args.db);
+  async run({ args }) {
+    const obsxa = await open(args.db);
     try {
-      const rows = obsxa.analysis.unpromoted(args.projectId);
+      const rows = await obsxa.analysis.unpromoted(args.projectId);
       if (args.toon || args.json) return output(rows, args.toon);
       if (rows.length === 0) return consola.info("No unpromoted observations found.");
       for (const row of rows) {
         consola.log(`#${row.id} ${row.title}`);
       }
     } finally {
-      obsxa.close();
+      await obsxa.close();
     }
   },
 });

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -6,8 +6,8 @@ import type { Observation, ProjectStats, TriageRow } from "../types.ts";
 
 export function createAnalysisStore(db: ObsxaDB) {
   return {
-    stats(projectId: string): ProjectStats {
-      const rows = db
+    async stats(projectId: string): Promise<ProjectStats> {
+      const rows = await db
         .select()
         .from(observations)
         .where(eq(observations.projectId, projectId))
@@ -21,11 +21,13 @@ export function createAnalysisStore(db: ObsxaDB) {
       const avgConfidence =
         total > 0 ? Math.round(rows.reduce((sum, row) => sum + row.confidence, 0) / total) : 0;
 
-      const totalClusters = db
-        .select({ id: clusters.id })
-        .from(clusters)
-        .where(eq(clusters.projectId, projectId))
-        .all().length;
+      const totalClusters = (
+        await db
+          .select({ id: clusters.id })
+          .from(clusters)
+          .where(eq(clusters.projectId, projectId))
+          .all()
+      ).length;
 
       return {
         total,
@@ -45,20 +47,22 @@ export function createAnalysisStore(db: ObsxaDB) {
       };
     },
 
-    frequent(projectId: string): Observation[] {
-      return db
-        .select()
-        .from(observations)
-        .where(
-          and(eq(observations.projectId, projectId), notInArray(observations.frequency, [0, 1])),
-        )
-        .all()
+    async frequent(projectId: string): Promise<Observation[]> {
+      return (
+        await db
+          .select()
+          .from(observations)
+          .where(
+            and(eq(observations.projectId, projectId), notInArray(observations.frequency, [0, 1])),
+          )
+          .all()
+      )
         .map(toObservation)
         .sort((a, b) => b.frequency - a.frequency);
     },
 
-    isolated(projectId: string): Observation[] {
-      const projectObservations = db
+    async isolated(projectId: string): Promise<Observation[]> {
+      const projectObservations = await db
         .select({ id: observations.id })
         .from(observations)
         .where(eq(observations.projectId, projectId))
@@ -66,7 +70,7 @@ export function createAnalysisStore(db: ObsxaDB) {
       const ids = projectObservations.map((row) => row.id);
       if (ids.length === 0) return [];
 
-      const relationRows = db
+      const relationRows = await db
         .select({
           fromObservationId: observationRelations.fromObservationId,
           toObservationId: observationRelations.toObservationId,
@@ -86,17 +90,15 @@ export function createAnalysisStore(db: ObsxaDB) {
         relatedIds.add(row.toObservationId);
       }
 
-      return db
-        .select()
-        .from(observations)
-        .where(eq(observations.projectId, projectId))
-        .all()
+      return (
+        await db.select().from(observations).where(eq(observations.projectId, projectId)).all()
+      )
         .filter((row) => !relatedIds.has(row.id))
         .map(toObservation);
     },
 
-    convergent(projectId: string): Observation[] {
-      const allObs = db
+    async convergent(projectId: string): Promise<Observation[]> {
+      const allObs = await db
         .select()
         .from(observations)
         .where(eq(observations.projectId, projectId))
@@ -106,7 +108,7 @@ export function createAnalysisStore(db: ObsxaDB) {
       const byId = new Map(allObs.map((o) => [o.id, o]));
       const ids = allObs.map((o) => o.id);
 
-      const supports = db
+      const supports = await db
         .select()
         .from(observationRelations)
         .where(
@@ -132,27 +134,34 @@ export function createAnalysisStore(db: ObsxaDB) {
         .map(toObservation);
     },
 
-    promoted(projectId: string): Observation[] {
-      return db
-        .select()
-        .from(observations)
-        .where(and(eq(observations.projectId, projectId), eq(observations.status, "promoted")))
-        .all()
-        .map(toObservation);
+    async promoted(projectId: string): Promise<Observation[]> {
+      return (
+        await db
+          .select()
+          .from(observations)
+          .where(and(eq(observations.projectId, projectId), eq(observations.status, "promoted")))
+          .all()
+      ).map(toObservation);
     },
 
-    unpromoted(projectId: string): Observation[] {
-      return db
-        .select()
-        .from(observations)
-        .where(and(eq(observations.projectId, projectId), eq(observations.status, "active")))
-        .all()
+    async unpromoted(projectId: string): Promise<Observation[]> {
+      return (
+        await db
+          .select()
+          .from(observations)
+          .where(and(eq(observations.projectId, projectId), eq(observations.status, "active")))
+          .all()
+      )
         .filter((row) => row.promotedTo === null)
         .map(toObservation);
     },
 
-    triage(projectId: string, limit = 25, sort: "triage" | "recent" = "triage"): TriageRow[] {
-      const activeRows = db
+    async triage(
+      projectId: string,
+      limit = 25,
+      sort: "triage" | "recent" = "triage",
+    ): Promise<TriageRow[]> {
+      const activeRows = await db
         .select()
         .from(observations)
         .where(and(eq(observations.projectId, projectId), eq(observations.status, "active")))
@@ -161,7 +170,7 @@ export function createAnalysisStore(db: ObsxaDB) {
       const ids = activeRows.map((row) => row.id);
       if (ids.length === 0) return [];
 
-      const relations = db
+      const relations = await db
         .select()
         .from(observationRelations)
         .where(

--- a/src/core/cluster.ts
+++ b/src/core/cluster.ts
@@ -25,15 +25,15 @@ function toClusterMember(row: typeof clusterMembers.$inferSelect): ClusterMember
 
 export function createClusterStore(db: ObsxaDB) {
   return {
-    add(input: AddCluster): Cluster {
-      const project = db
+    async add(input: AddCluster): Promise<Cluster> {
+      const project = await db
         .select({ id: projects.id })
         .from(projects)
         .where(eq(projects.id, input.projectId))
         .get();
       if (!project) throw new Error(`Project "${input.projectId}" not found`);
 
-      const row = db
+      const row = await db
         .insert(clusters)
         .values({
           projectId: input.projectId,
@@ -46,29 +46,26 @@ export function createClusterStore(db: ObsxaDB) {
       return toCluster(row);
     },
 
-    list(projectId: string): Cluster[] {
-      return db
-        .select()
-        .from(clusters)
-        .where(eq(clusters.projectId, projectId))
-        .all()
-        .map(toCluster);
+    async list(projectId: string): Promise<Cluster[]> {
+      return (await db.select().from(clusters).where(eq(clusters.projectId, projectId)).all()).map(
+        toCluster,
+      );
     },
 
-    get(id: number): Cluster | null {
-      const row = db.select().from(clusters).where(eq(clusters.id, id)).get();
+    async get(id: number): Promise<Cluster | null> {
+      const row = await db.select().from(clusters).where(eq(clusters.id, id)).get();
       return row ? toCluster(row) : null;
     },
 
-    addMember(clusterId: number, observationId: number): ClusterMember {
-      const cluster = db
+    async addMember(clusterId: number, observationId: number): Promise<ClusterMember> {
+      const cluster = await db
         .select({ id: clusters.id, projectId: clusters.projectId })
         .from(clusters)
         .where(eq(clusters.id, clusterId))
         .get();
       if (!cluster) throw new Error(`Cluster #${clusterId} not found`);
 
-      const observation = db
+      const observation = await db
         .select({ id: observations.id, projectId: observations.projectId })
         .from(observations)
         .where(eq(observations.id, observationId))
@@ -81,7 +78,7 @@ export function createClusterStore(db: ObsxaDB) {
         );
       }
 
-      const existing = db
+      const existing = await db
         .select()
         .from(clusterMembers)
         .where(
@@ -93,12 +90,16 @@ export function createClusterStore(db: ObsxaDB) {
         .get();
       if (existing) return toClusterMember(existing);
 
-      const row = db.insert(clusterMembers).values({ clusterId, observationId }).returning().get();
+      const row = await db
+        .insert(clusterMembers)
+        .values({ clusterId, observationId })
+        .returning()
+        .get();
       return toClusterMember(row);
     },
 
-    listMembers(clusterId: number): Observation[] {
-      const rows = db
+    async listMembers(clusterId: number): Promise<Observation[]> {
+      const rows = await db
         .select({ observation: observations })
         .from(clusterMembers)
         .innerJoin(observations, eq(clusterMembers.observationId, observations.id))
@@ -108,8 +109,8 @@ export function createClusterStore(db: ObsxaDB) {
       return rows.map((row) => toObservation(row.observation));
     },
 
-    removeMember(memberId: number): void {
-      db.delete(clusterMembers).where(eq(clusterMembers.id, memberId)).run();
+    async removeMember(memberId: number): Promise<void> {
+      await db.delete(clusterMembers).where(eq(clusterMembers.id, memberId)).run();
     },
   };
 }

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -1,7 +1,7 @@
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
 
-export type ObsxaDB = BetterSQLite3Database;
+export type ObsxaDB = LibSQLDatabase;
 
 export const projects = sqliteTable("projects", {
   id: text("id").primaryKey(),

--- a/src/core/dedup.ts
+++ b/src/core/dedup.ts
@@ -120,13 +120,10 @@ function mergeConfidence(
 
 export function createDedupStore(db: ObsxaDB) {
   return {
-    scan(projectId: string, threshold = 0.72): ScanDuplicatesResult {
-      const rows = db
-        .select()
-        .from(observations)
-        .where(eq(observations.projectId, projectId))
-        .all()
-        .map(toObservation);
+    async scan(projectId: string, threshold = 0.72): Promise<ScanDuplicatesResult> {
+      const rows = (
+        await db.select().from(observations).where(eq(observations.projectId, projectId)).all()
+      ).map(toObservation);
 
       const results: DuplicateCandidate[] = [];
       let checkedPairs = 0;
@@ -202,7 +199,7 @@ export function createDedupStore(db: ObsxaDB) {
           if (!reason) continue;
 
           const storedScore = Math.round(score * 1000);
-          const existing = db
+          const existing = await db
             .select()
             .from(duplicateCandidates)
             .where(
@@ -214,7 +211,7 @@ export function createDedupStore(db: ObsxaDB) {
             .get();
 
           if (existing) {
-            const updated = db
+            const updated = await db
               .update(duplicateCandidates)
               .set({
                 reason,
@@ -228,7 +225,7 @@ export function createDedupStore(db: ObsxaDB) {
             continue;
           }
 
-          const inserted = db
+          const inserted = await db
             .insert(duplicateCandidates)
             .values({
               projectId,
@@ -247,37 +244,44 @@ export function createDedupStore(db: ObsxaDB) {
       return { candidates: results.sort((a, b) => b.score - a.score), checkedPairs };
     },
 
-    candidates(
+    async candidates(
       projectId: string,
       status: DuplicateCandidateStatus | "all" = "open",
-    ): DuplicateCandidate[] {
+    ): Promise<DuplicateCandidate[]> {
       if (status === "all") {
-        return db
-          .select()
-          .from(duplicateCandidates)
-          .where(eq(duplicateCandidates.projectId, projectId))
-          .all()
+        return (
+          await db
+            .select()
+            .from(duplicateCandidates)
+            .where(eq(duplicateCandidates.projectId, projectId))
+            .all()
+        )
           .map(toCandidate)
           .sort((a, b) => b.score - a.score);
       }
 
-      return db
-        .select()
-        .from(duplicateCandidates)
-        .where(
-          and(eq(duplicateCandidates.projectId, projectId), eq(duplicateCandidates.status, status)),
-        )
-        .all()
+      return (
+        await db
+          .select()
+          .from(duplicateCandidates)
+          .where(
+            and(
+              eq(duplicateCandidates.projectId, projectId),
+              eq(duplicateCandidates.status, status),
+            ),
+          )
+          .all()
+      )
         .map(toCandidate)
         .sort((a, b) => b.score - a.score);
     },
 
-    review(
+    async review(
       candidateId: number,
       status: DuplicateCandidateStatus,
       reason: string,
-    ): CandidateReviewResult {
-      const current = db
+    ): Promise<CandidateReviewResult> {
+      const current = await db
         .select()
         .from(duplicateCandidates)
         .where(eq(duplicateCandidates.id, candidateId))
@@ -286,14 +290,14 @@ export function createDedupStore(db: ObsxaDB) {
       if (current.status === status)
         throw new Error(`Candidate #${candidateId} is already ${status}`);
 
-      const updated = db
+      const updated = await db
         .update(duplicateCandidates)
         .set({ status, updatedAt: new Date() })
         .where(eq(duplicateCandidates.id, candidateId))
         .returning()
         .get();
 
-      const event = db
+      const event = await db
         .insert(duplicateCandidateEvents)
         .values({
           candidateId,
@@ -310,22 +314,22 @@ export function createDedupStore(db: ObsxaDB) {
       };
     },
 
-    merge(
+    async merge(
       primaryObservationId: number,
       duplicateObservationId: number,
       options: MergeOptions = {},
-    ): MergeResult {
+    ): Promise<MergeResult> {
       if (primaryObservationId === duplicateObservationId) {
         throw new Error("Cannot merge observation into itself");
       }
 
-      return db.transaction((tx) => {
-        const primaryRow = tx
+      return db.transaction(async (tx) => {
+        const primaryRow = await tx
           .select()
           .from(observations)
           .where(eq(observations.id, primaryObservationId))
           .get();
-        const duplicateRow = tx
+        const duplicateRow = await tx
           .select()
           .from(observations)
           .where(eq(observations.id, duplicateObservationId))
@@ -365,7 +369,7 @@ export function createDedupStore(db: ObsxaDB) {
           frequency: mergedFrequency,
         });
 
-        const updatedPrimaryRow = tx
+        const updatedPrimaryRow = await tx
           .update(observations)
           .set({
             description,
@@ -381,7 +385,8 @@ export function createDedupStore(db: ObsxaDB) {
           .returning()
           .get();
 
-        tx.update(observations)
+        await tx
+          .update(observations)
           .set({
             status: "archived",
             archivedReasonCode: "merged",
@@ -391,7 +396,8 @@ export function createDedupStore(db: ObsxaDB) {
           .where(eq(observations.id, duplicateObservationId))
           .run();
 
-        tx.insert(observationStatusEvents)
+        await tx
+          .insert(observationStatusEvents)
           .values({
             observationId: duplicateObservationId,
             fromStatus: duplicate.status,
@@ -401,7 +407,7 @@ export function createDedupStore(db: ObsxaDB) {
           })
           .run();
 
-        const primaryFromRelations = tx
+        const primaryFromRelations = await tx
           .select({
             to: observationRelations.toObservationId,
             type: observationRelations.type,
@@ -409,7 +415,7 @@ export function createDedupStore(db: ObsxaDB) {
           .from(observationRelations)
           .where(eq(observationRelations.fromObservationId, primaryObservationId))
           .all();
-        const primaryToRelations = tx
+        const primaryToRelations = await tx
           .select({
             from: observationRelations.fromObservationId,
             type: observationRelations.type,
@@ -421,7 +427,7 @@ export function createDedupStore(db: ObsxaDB) {
         const primaryFromKeys = new Set(primaryFromRelations.map((r) => `${r.to}:${r.type}`));
         const primaryToKeys = new Set(primaryToRelations.map((r) => `${r.from}:${r.type}`));
 
-        const duplicateFromRelations = tx
+        const duplicateFromRelations = await tx
           .select({
             id: observationRelations.id,
             to: observationRelations.toObservationId,
@@ -430,7 +436,7 @@ export function createDedupStore(db: ObsxaDB) {
           .from(observationRelations)
           .where(eq(observationRelations.fromObservationId, duplicateObservationId))
           .all();
-        const duplicateToRelations = tx
+        const duplicateToRelations = await tx
           .select({
             id: observationRelations.id,
             from: observationRelations.fromObservationId,
@@ -442,32 +448,35 @@ export function createDedupStore(db: ObsxaDB) {
 
         for (const rel of duplicateFromRelations) {
           if (primaryFromKeys.has(`${rel.to}:${rel.type}`)) {
-            tx.delete(observationRelations).where(eq(observationRelations.id, rel.id)).run();
+            await tx.delete(observationRelations).where(eq(observationRelations.id, rel.id)).run();
           }
         }
         for (const rel of duplicateToRelations) {
           if (primaryToKeys.has(`${rel.from}:${rel.type}`)) {
-            tx.delete(observationRelations).where(eq(observationRelations.id, rel.id)).run();
+            await tx.delete(observationRelations).where(eq(observationRelations.id, rel.id)).run();
           }
         }
 
-        tx.update(observationRelations)
+        await tx
+          .update(observationRelations)
           .set({ fromObservationId: primaryObservationId })
           .where(eq(observationRelations.fromObservationId, duplicateObservationId))
           .run();
 
-        tx.update(observationRelations)
+        await tx
+          .update(observationRelations)
           .set({ toObservationId: primaryObservationId })
           .where(eq(observationRelations.toObservationId, duplicateObservationId))
           .run();
 
-        tx.delete(observationRelations)
+        await tx
+          .delete(observationRelations)
           .where(
             sql`${observationRelations.fromObservationId} = ${observationRelations.toObservationId}`,
           )
           .run();
 
-        const relationRows = tx
+        const relationRows = await tx
           .select()
           .from(observationRelations)
           .where(
@@ -481,7 +490,8 @@ export function createDedupStore(db: ObsxaDB) {
         for (const relationRow of relationRows) {
           const key = `${relationRow.fromObservationId}:${relationRow.toObservationId}:${relationRow.type}`;
           if (seen.has(key)) {
-            tx.delete(observationRelations)
+            await tx
+              .delete(observationRelations)
               .where(eq(observationRelations.id, relationRow.id))
               .run();
             continue;
@@ -489,13 +499,13 @@ export function createDedupStore(db: ObsxaDB) {
           seen.add(key);
         }
 
-        const duplicateMemberships = tx
+        const duplicateMemberships = await tx
           .select()
           .from(clusterMembers)
           .where(eq(clusterMembers.observationId, duplicateObservationId))
           .all();
         for (const member of duplicateMemberships) {
-          const existingPrimaryMembership = tx
+          const existingPrimaryMembership = await tx
             .select()
             .from(clusterMembers)
             .where(
@@ -506,12 +516,13 @@ export function createDedupStore(db: ObsxaDB) {
             )
             .get();
           if (!existingPrimaryMembership) {
-            tx.update(clusterMembers)
+            await tx
+              .update(clusterMembers)
               .set({ observationId: primaryObservationId })
               .where(eq(clusterMembers.id, member.id))
               .run();
           } else {
-            tx.delete(clusterMembers).where(eq(clusterMembers.id, member.id)).run();
+            await tx.delete(clusterMembers).where(eq(clusterMembers.id, member.id)).run();
           }
         }
 
@@ -520,7 +531,7 @@ export function createDedupStore(db: ObsxaDB) {
         const relationNotes = options.relationNotes ?? `Merged into #${primaryObservationId}`;
         let relation: ObservationRelation | null = null;
 
-        const existingRelation = tx
+        const existingRelation = await tx
           .select()
           .from(observationRelations)
           .where(
@@ -533,13 +544,13 @@ export function createDedupStore(db: ObsxaDB) {
           .get();
 
         const relationRow = existingRelation
-          ? tx
+          ? await tx
               .update(observationRelations)
               .set({ confidence: relationConfidence, notes: relationNotes })
               .where(eq(observationRelations.id, existingRelation.id))
               .returning()
               .get()
-          : tx
+          : await tx
               .insert(observationRelations)
               .values({
                 fromObservationId: duplicateObservationId,
@@ -558,7 +569,7 @@ export function createDedupStore(db: ObsxaDB) {
           mergedTagsCount: mergedTags.length,
           confidenceStrategy,
         });
-        const mergeRow = tx
+        const mergeRow = await tx
           .insert(observationMerges)
           .values({
             projectId: primary.projectId,
@@ -571,7 +582,7 @@ export function createDedupStore(db: ObsxaDB) {
           .returning()
           .get();
 
-        const relatedCandidates = tx
+        const relatedCandidates = await tx
           .select()
           .from(duplicateCandidates)
           .where(
@@ -587,12 +598,14 @@ export function createDedupStore(db: ObsxaDB) {
 
         for (const candidate of relatedCandidates) {
           if (candidate.status !== "resolved") {
-            tx.update(duplicateCandidates)
+            await tx
+              .update(duplicateCandidates)
               .set({ status: "resolved", updatedAt: new Date() })
               .where(eq(duplicateCandidates.id, candidate.id))
               .run();
 
-            tx.insert(duplicateCandidateEvents)
+            await tx
+              .insert(duplicateCandidateEvents)
               .values({
                 candidateId: candidate.id,
                 fromStatus: candidate.status,
@@ -603,7 +616,7 @@ export function createDedupStore(db: ObsxaDB) {
           }
         }
 
-        const mergedRow = tx
+        const mergedRow = await tx
           .select()
           .from(observations)
           .where(eq(observations.id, duplicateObservationId))

--- a/src/core/observation.ts
+++ b/src/core/observation.ts
@@ -42,8 +42,8 @@ function toTransition(row: typeof observationStatusEvents.$inferSelect): Observa
 
 export function createObservationStore(db: ObsxaDB) {
   return {
-    add(input: AddObservation): Observation {
-      const project = db
+    async add(input: AddObservation): Promise<Observation> {
+      const project = await db
         .select({ id: projects.id })
         .from(projects)
         .where(eq(projects.id, input.projectId))
@@ -62,7 +62,7 @@ export function createObservationStore(db: ObsxaDB) {
         frequency: 1,
       });
 
-      const row = db
+      const row = await db
         .insert(observations)
         .values({
           projectId: input.projectId,
@@ -91,85 +91,97 @@ export function createObservationStore(db: ObsxaDB) {
       return toObservation(row);
     },
 
-    addMany(records: ObservationImportRecord[]): Observation[] {
-      return records.map((record) => {
+    async addMany(records: ObservationImportRecord[]): Promise<Observation[]> {
+      const results: Observation[] = [];
+      for (const record of records) {
         if (record.status === "promoted" && !record.promotedTo) {
           throw new Error("Imported promoted observations must include promotedTo");
         }
-        const created = this.add(record);
+        const created = await this.add(record);
         if (record.status === "dismissed") {
-          return this.dismiss(created.id, {
-            reasonCode: "manual_review",
-            reasonNote: "Imported as dismissed",
-          });
+          results.push(
+            await this.dismiss(created.id, {
+              reasonCode: "manual_review",
+              reasonNote: "Imported as dismissed",
+            }),
+          );
+          continue;
         }
         if (record.status === "archived") {
-          return this.archive(created.id, {
-            reasonCode: "manual_review",
-            reasonNote: "Imported as archived",
-          });
+          results.push(
+            await this.archive(created.id, {
+              reasonCode: "manual_review",
+              reasonNote: "Imported as archived",
+            }),
+          );
+          continue;
         }
         if (record.status === "promoted") {
-          return this.promote(created.id, record.promotedTo!);
+          results.push(await this.promote(created.id, record.promotedTo!));
+          continue;
         }
-        return created;
-      });
+        results.push(created);
+      }
+      return results;
     },
 
-    get(id: number): Observation | null {
-      const row = db.select().from(observations).where(eq(observations.id, id)).get();
+    async get(id: number): Promise<Observation | null> {
+      const row = await db.select().from(observations).where(eq(observations.id, id)).get();
       return row ? toObservation(row) : null;
     },
 
-    list(
+    async list(
       projectId: string,
       opts?: {
         status?: ObservationStatus;
         type?: ObservationType;
         sourceType?: SourceType;
       },
-    ): Observation[] {
+    ): Promise<Observation[]> {
       const conditions = [eq(observations.projectId, projectId)];
       if (opts?.status) conditions.push(eq(observations.status, opts.status));
       if (opts?.type) conditions.push(eq(observations.type, opts.type));
       if (opts?.sourceType) conditions.push(eq(observations.sourceType, opts.sourceType));
-      return db
-        .select()
-        .from(observations)
-        .where(and(...conditions))
-        .all()
-        .map(toObservation);
+      return (
+        await db
+          .select()
+          .from(observations)
+          .where(and(...conditions))
+          .all()
+      ).map(toObservation);
     },
 
-    transitions(observationId: number): ObservationTransition[] {
-      return db
-        .select()
-        .from(observationStatusEvents)
-        .where(eq(observationStatusEvents.observationId, observationId))
-        .orderBy(asc(observationStatusEvents.createdAt), asc(observationStatusEvents.id))
-        .all()
-        .map(toTransition);
+    async transitions(observationId: number): Promise<ObservationTransition[]> {
+      return (
+        await db
+          .select()
+          .from(observationStatusEvents)
+          .where(eq(observationStatusEvents.observationId, observationId))
+          .orderBy(asc(observationStatusEvents.createdAt), asc(observationStatusEvents.id))
+          .all()
+      ).map(toTransition);
     },
 
-    edits(observationId: number): ObservationEdit[] {
-      return db
-        .select()
-        .from(observationEdits)
-        .where(eq(observationEdits.observationId, observationId))
-        .orderBy(asc(observationEdits.createdAt), asc(observationEdits.id))
-        .all()
-        .map((row) => ({
-          id: row.id,
-          observationId: row.observationId,
-          field: row.field,
-          oldValue: row.oldValue,
-          newValue: row.newValue,
-          createdAt: row.createdAt,
-        }));
+    async edits(observationId: number): Promise<ObservationEdit[]> {
+      return (
+        await db
+          .select()
+          .from(observationEdits)
+          .where(eq(observationEdits.observationId, observationId))
+          .orderBy(asc(observationEdits.createdAt), asc(observationEdits.id))
+          .all()
+      ).map((row) => ({
+        id: row.id,
+        observationId: row.observationId,
+        field: row.field,
+        oldValue: row.oldValue,
+        newValue: row.newValue,
+        createdAt: row.createdAt,
+      }));
     },
 
-    update(id: number, fields: UpdateObservation): Observation {
-      const current = db.select().from(observations).where(eq(observations.id, id)).get();
+    async update(id: number, fields: UpdateObservation): Promise<Observation> {
+      const current = await db.select().from(observations).where(eq(observations.id, id)).get();
       if (!current) throw new Error(`Observation #${id} not found`);
 
       const values: Record<string, unknown> = { updatedAt: new Date() };
@@ -269,8 +281,8 @@ export function createObservationStore(db: ObsxaDB) {
         frequency: current.frequency,
       });
 
-      return db.transaction((tx) => {
-        const row = tx
+      return db.transaction(async (tx) => {
+        const row = await tx
           .update(observations)
           .set(values)
           .where(eq(observations.id, id))
@@ -278,7 +290,8 @@ export function createObservationStore(db: ObsxaDB) {
           .get();
 
         for (const edit of editRecords) {
-          tx.insert(observationEdits)
+          await tx
+            .insert(observationEdits)
             .values({
               observationId: id,
               field: edit.field,
@@ -292,15 +305,17 @@ export function createObservationStore(db: ObsxaDB) {
       });
     },
 
-    updateMany(records: ObservationBatchUpdateRecord[]): Observation[] {
-      return records.map((record) => {
+    async updateMany(records: ObservationBatchUpdateRecord[]): Promise<Observation[]> {
+      const updated: Observation[] = [];
+      for (const record of records) {
         const { id, ...fields } = record;
-        return this.update(id, fields);
-      });
+        updated.push(await this.update(id, fields));
+      }
+      return updated;
     },
 
-    dismiss(id: number, transition: TransitionObservation): Observation {
-      const existing = db.select().from(observations).where(eq(observations.id, id)).get();
+    async dismiss(id: number, transition: TransitionObservation): Promise<Observation> {
+      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
       if (!existing) throw new Error(`Observation #${id} not found`);
       if (existing.status !== "active") {
         throw new Error(
@@ -308,8 +323,8 @@ export function createObservationStore(db: ObsxaDB) {
         );
       }
 
-      return db.transaction((tx) => {
-        const row = tx
+      return db.transaction(async (tx) => {
+        const row = await tx
           .update(observations)
           .set({
             status: "dismissed",
@@ -321,7 +336,8 @@ export function createObservationStore(db: ObsxaDB) {
           .returning()
           .get();
 
-        tx.insert(observationStatusEvents)
+        await tx
+          .insert(observationStatusEvents)
           .values({
             observationId: id,
             fromStatus: existing.status,
@@ -335,8 +351,8 @@ export function createObservationStore(db: ObsxaDB) {
       });
     },
 
-    archive(id: number, transition: TransitionObservation): Observation {
-      const existing = db.select().from(observations).where(eq(observations.id, id)).get();
+    async archive(id: number, transition: TransitionObservation): Promise<Observation> {
+      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
       if (!existing) throw new Error(`Observation #${id} not found`);
       if (existing.status !== "active") {
         throw new Error(
@@ -344,8 +360,8 @@ export function createObservationStore(db: ObsxaDB) {
         );
       }
 
-      return db.transaction((tx) => {
-        const row = tx
+      return db.transaction(async (tx) => {
+        const row = await tx
           .update(observations)
           .set({
             status: "archived",
@@ -357,7 +373,8 @@ export function createObservationStore(db: ObsxaDB) {
           .returning()
           .get();
 
-        tx.insert(observationStatusEvents)
+        await tx
+          .insert(observationStatusEvents)
           .values({
             observationId: id,
             fromStatus: existing.status,
@@ -371,8 +388,8 @@ export function createObservationStore(db: ObsxaDB) {
       });
     },
 
-    incrementFrequency(id: number): Observation {
-      const existing = db.select().from(observations).where(eq(observations.id, id)).get();
+    async incrementFrequency(id: number): Promise<Observation> {
+      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
       if (!existing) throw new Error(`Observation #${id} not found`);
 
       const frequency = existing.frequency + 1;
@@ -384,7 +401,7 @@ export function createObservationStore(db: ObsxaDB) {
         frequency,
       });
 
-      const row = db
+      const row = await db
         .update(observations)
         .set({ frequency, triageScore, updatedAt: new Date() })
         .where(eq(observations.id, id))
@@ -393,8 +410,8 @@ export function createObservationStore(db: ObsxaDB) {
       return toObservation(row);
     },
 
-    promote(id: number, hypothesisRef: string): Observation {
-      const existing = db.select().from(observations).where(eq(observations.id, id)).get();
+    async promote(id: number, hypothesisRef: string): Promise<Observation> {
+      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
       if (!existing) throw new Error(`Observation #${id} not found`);
       if (existing.status !== "active") {
         throw new Error(
@@ -402,8 +419,8 @@ export function createObservationStore(db: ObsxaDB) {
         );
       }
 
-      return db.transaction((tx) => {
-        const row = tx
+      return db.transaction(async (tx) => {
+        const row = await tx
           .update(observations)
           .set({
             status: "promoted",
@@ -416,7 +433,8 @@ export function createObservationStore(db: ObsxaDB) {
           .returning()
           .get();
 
-        tx.insert(observationStatusEvents)
+        await tx
+          .insert(observationStatusEvents)
           .values({
             observationId: id,
             fromStatus: existing.status,

--- a/src/core/observation.ts
+++ b/src/core/observation.ts
@@ -181,107 +181,108 @@ export function createObservationStore(db: ObsxaDB) {
     },
 
     async update(id: number, fields: UpdateObservation): Promise<Observation> {
-      const current = await db.select().from(observations).where(eq(observations.id, id)).get();
-      if (!current) throw new Error(`Observation #${id} not found`);
-
-      const values: Record<string, unknown> = { updatedAt: new Date() };
-      const editRecords: { field: string; oldValue: string | null; newValue: string | null }[] = [];
-
-      function track(field: string, oldVal: unknown, newVal: unknown) {
-        const o = oldVal == null ? null : String(oldVal);
-        const n = newVal == null ? null : String(newVal);
-        if (o !== n) editRecords.push({ field, oldValue: o, newValue: n });
-      }
-
-      if (fields.title !== undefined) {
-        track("title", current.title, fields.title);
-        values.title = fields.title;
-      }
-      if (fields.description !== undefined) {
-        track("description", current.description, fields.description);
-        values.description = fields.description;
-      }
-      if (fields.type !== undefined) {
-        track("type", current.type, fields.type);
-        values.type = fields.type;
-      }
-      if (fields.source !== undefined) {
-        track("source", current.source, fields.source);
-        values.source = fields.source;
-      }
-      if (fields.sourceType !== undefined) {
-        track("sourceType", current.sourceType, fields.sourceType);
-        values.sourceType = fields.sourceType;
-      }
-      if (fields.confidence !== undefined) {
-        const v = clampPercent(fields.confidence, current.confidence);
-        track("confidence", current.confidence, v);
-        values.confidence = v;
-      }
-      if (fields.tags !== undefined) {
-        const v = JSON.stringify(fields.tags);
-        track("tags", current.tags, v);
-        values.tags = v;
-      }
-      if (fields.data !== undefined) {
-        track("data", current.data, fields.data);
-        values.data = fields.data;
-      }
-      if (fields.context !== undefined) {
-        track("context", current.context, fields.context);
-        values.context = fields.context;
-      }
-      if (fields.capturedAt !== undefined) {
-        const v = parseDate(fields.capturedAt);
-        track("capturedAt", current.capturedAt?.getTime() ?? null, v?.getTime() ?? null);
-        values.capturedAt = v;
-      }
-      if (fields.sourceRef !== undefined) {
-        track("sourceRef", current.sourceRef, fields.sourceRef);
-        values.sourceRef = fields.sourceRef;
-      }
-      if (fields.collector !== undefined) {
-        track("collector", current.collector, fields.collector);
-        values.collector = fields.collector;
-      }
-      if (fields.inputHash !== undefined) {
-        track("inputHash", current.inputHash, fields.inputHash);
-        values.inputHash = fields.inputHash;
-      }
-      if (fields.evidenceStrength !== undefined) {
-        const v = clampPercent(fields.evidenceStrength, current.evidenceStrength);
-        track("evidenceStrength", current.evidenceStrength, v);
-        values.evidenceStrength = v;
-      }
-      if (fields.novelty !== undefined) {
-        const v = clampPercent(fields.novelty, current.novelty);
-        track("novelty", current.novelty, v);
-        values.novelty = v;
-      }
-      if (fields.uncertainty !== undefined) {
-        const v = clampPercent(fields.uncertainty, current.uncertainty);
-        track("uncertainty", current.uncertainty, v);
-        values.uncertainty = v;
-      }
-      if (fields.reproducibilityHint !== undefined) {
-        track("reproducibilityHint", current.reproducibilityHint, fields.reproducibilityHint);
-        values.reproducibilityHint = fields.reproducibilityHint;
-      }
-
-      const nextConfidence = (values.confidence as number | undefined) ?? current.confidence;
-      const nextEvidence =
-        (values.evidenceStrength as number | undefined) ?? current.evidenceStrength;
-      const nextNovelty = (values.novelty as number | undefined) ?? current.novelty;
-      const nextUncertainty = (values.uncertainty as number | undefined) ?? current.uncertainty;
-      values.triageScore = computeTriageScore({
-        confidence: nextConfidence,
-        evidenceStrength: nextEvidence,
-        novelty: nextNovelty,
-        uncertainty: nextUncertainty,
-        frequency: current.frequency,
-      });
-
       return db.transaction(async (tx) => {
+        const current = await tx.select().from(observations).where(eq(observations.id, id)).get();
+        if (!current) throw new Error(`Observation #${id} not found`);
+
+        const values: Record<string, unknown> = { updatedAt: new Date() };
+        const editRecords: { field: string; oldValue: string | null; newValue: string | null }[] =
+          [];
+
+        function track(field: string, oldVal: unknown, newVal: unknown) {
+          const o = oldVal == null ? null : String(oldVal);
+          const n = newVal == null ? null : String(newVal);
+          if (o !== n) editRecords.push({ field, oldValue: o, newValue: n });
+        }
+
+        if (fields.title !== undefined) {
+          track("title", current.title, fields.title);
+          values.title = fields.title;
+        }
+        if (fields.description !== undefined) {
+          track("description", current.description, fields.description);
+          values.description = fields.description;
+        }
+        if (fields.type !== undefined) {
+          track("type", current.type, fields.type);
+          values.type = fields.type;
+        }
+        if (fields.source !== undefined) {
+          track("source", current.source, fields.source);
+          values.source = fields.source;
+        }
+        if (fields.sourceType !== undefined) {
+          track("sourceType", current.sourceType, fields.sourceType);
+          values.sourceType = fields.sourceType;
+        }
+        if (fields.confidence !== undefined) {
+          const v = clampPercent(fields.confidence, current.confidence);
+          track("confidence", current.confidence, v);
+          values.confidence = v;
+        }
+        if (fields.tags !== undefined) {
+          const v = JSON.stringify(fields.tags);
+          track("tags", current.tags, v);
+          values.tags = v;
+        }
+        if (fields.data !== undefined) {
+          track("data", current.data, fields.data);
+          values.data = fields.data;
+        }
+        if (fields.context !== undefined) {
+          track("context", current.context, fields.context);
+          values.context = fields.context;
+        }
+        if (fields.capturedAt !== undefined) {
+          const v = parseDate(fields.capturedAt);
+          track("capturedAt", current.capturedAt?.getTime() ?? null, v?.getTime() ?? null);
+          values.capturedAt = v;
+        }
+        if (fields.sourceRef !== undefined) {
+          track("sourceRef", current.sourceRef, fields.sourceRef);
+          values.sourceRef = fields.sourceRef;
+        }
+        if (fields.collector !== undefined) {
+          track("collector", current.collector, fields.collector);
+          values.collector = fields.collector;
+        }
+        if (fields.inputHash !== undefined) {
+          track("inputHash", current.inputHash, fields.inputHash);
+          values.inputHash = fields.inputHash;
+        }
+        if (fields.evidenceStrength !== undefined) {
+          const v = clampPercent(fields.evidenceStrength, current.evidenceStrength);
+          track("evidenceStrength", current.evidenceStrength, v);
+          values.evidenceStrength = v;
+        }
+        if (fields.novelty !== undefined) {
+          const v = clampPercent(fields.novelty, current.novelty);
+          track("novelty", current.novelty, v);
+          values.novelty = v;
+        }
+        if (fields.uncertainty !== undefined) {
+          const v = clampPercent(fields.uncertainty, current.uncertainty);
+          track("uncertainty", current.uncertainty, v);
+          values.uncertainty = v;
+        }
+        if (fields.reproducibilityHint !== undefined) {
+          track("reproducibilityHint", current.reproducibilityHint, fields.reproducibilityHint);
+          values.reproducibilityHint = fields.reproducibilityHint;
+        }
+
+        const nextConfidence = (values.confidence as number | undefined) ?? current.confidence;
+        const nextEvidence =
+          (values.evidenceStrength as number | undefined) ?? current.evidenceStrength;
+        const nextNovelty = (values.novelty as number | undefined) ?? current.novelty;
+        const nextUncertainty = (values.uncertainty as number | undefined) ?? current.uncertainty;
+        values.triageScore = computeTriageScore({
+          confidence: nextConfidence,
+          evidenceStrength: nextEvidence,
+          novelty: nextNovelty,
+          uncertainty: nextUncertainty,
+          frequency: current.frequency,
+        });
+
         const row = await tx
           .update(observations)
           .set(values)
@@ -315,15 +316,15 @@ export function createObservationStore(db: ObsxaDB) {
     },
 
     async dismiss(id: number, transition: TransitionObservation): Promise<Observation> {
-      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
-      if (!existing) throw new Error(`Observation #${id} not found`);
-      if (existing.status !== "active") {
-        throw new Error(
-          `Observation #${id} must be active to dismiss (current: ${existing.status})`,
-        );
-      }
-
       return db.transaction(async (tx) => {
+        const existing = await tx.select().from(observations).where(eq(observations.id, id)).get();
+        if (!existing) throw new Error(`Observation #${id} not found`);
+        if (existing.status !== "active") {
+          throw new Error(
+            `Observation #${id} must be active to dismiss (current: ${existing.status})`,
+          );
+        }
+
         const row = await tx
           .update(observations)
           .set({
@@ -352,15 +353,15 @@ export function createObservationStore(db: ObsxaDB) {
     },
 
     async archive(id: number, transition: TransitionObservation): Promise<Observation> {
-      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
-      if (!existing) throw new Error(`Observation #${id} not found`);
-      if (existing.status !== "active") {
-        throw new Error(
-          `Observation #${id} must be active to archive (current: ${existing.status})`,
-        );
-      }
-
       return db.transaction(async (tx) => {
+        const existing = await tx.select().from(observations).where(eq(observations.id, id)).get();
+        if (!existing) throw new Error(`Observation #${id} not found`);
+        if (existing.status !== "active") {
+          throw new Error(
+            `Observation #${id} must be active to archive (current: ${existing.status})`,
+          );
+        }
+
         const row = await tx
           .update(observations)
           .set({
@@ -389,37 +390,39 @@ export function createObservationStore(db: ObsxaDB) {
     },
 
     async incrementFrequency(id: number): Promise<Observation> {
-      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
-      if (!existing) throw new Error(`Observation #${id} not found`);
+      return db.transaction(async (tx) => {
+        const existing = await tx.select().from(observations).where(eq(observations.id, id)).get();
+        if (!existing) throw new Error(`Observation #${id} not found`);
 
-      const frequency = existing.frequency + 1;
-      const triageScore = computeTriageScore({
-        confidence: existing.confidence,
-        evidenceStrength: existing.evidenceStrength,
-        novelty: existing.novelty,
-        uncertainty: existing.uncertainty,
-        frequency,
+        const frequency = existing.frequency + 1;
+        const triageScore = computeTriageScore({
+          confidence: existing.confidence,
+          evidenceStrength: existing.evidenceStrength,
+          novelty: existing.novelty,
+          uncertainty: existing.uncertainty,
+          frequency,
+        });
+
+        const row = await tx
+          .update(observations)
+          .set({ frequency, triageScore, updatedAt: new Date() })
+          .where(eq(observations.id, id))
+          .returning()
+          .get();
+        return toObservation(row);
       });
-
-      const row = await db
-        .update(observations)
-        .set({ frequency, triageScore, updatedAt: new Date() })
-        .where(eq(observations.id, id))
-        .returning()
-        .get();
-      return toObservation(row);
     },
 
     async promote(id: number, hypothesisRef: string): Promise<Observation> {
-      const existing = await db.select().from(observations).where(eq(observations.id, id)).get();
-      if (!existing) throw new Error(`Observation #${id} not found`);
-      if (existing.status !== "active") {
-        throw new Error(
-          `Observation #${id} must be active to promote (current: ${existing.status})`,
-        );
-      }
-
       return db.transaction(async (tx) => {
+        const existing = await tx.select().from(observations).where(eq(observations.id, id)).get();
+        if (!existing) throw new Error(`Observation #${id} not found`);
+        if (existing.status !== "active") {
+          throw new Error(
+            `Observation #${id} must be active to promote (current: ${existing.status})`,
+          );
+        }
+
         const row = await tx
           .update(observations)
           .set({

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -14,8 +14,8 @@ function toProject(row: typeof projects.$inferSelect): Project {
 
 export function createProjectStore(db: ObsxaDB) {
   return {
-    add(input: CreateProject): Project {
-      const row = db
+    async add(input: CreateProject): Promise<Project> {
+      const row = await db
         .insert(projects)
         .values({
           id: input.id,
@@ -28,17 +28,17 @@ export function createProjectStore(db: ObsxaDB) {
       return toProject(row);
     },
 
-    get(id: string): Project | null {
-      const row = db.select().from(projects).where(eq(projects.id, id)).get();
+    async get(id: string): Promise<Project | null> {
+      const row = await db.select().from(projects).where(eq(projects.id, id)).get();
       return row ? toProject(row) : null;
     },
 
-    list(): Project[] {
-      return db.select().from(projects).all().map(toProject);
+    async list(): Promise<Project[]> {
+      return (await db.select().from(projects).all()).map(toProject);
     },
 
-    remove(id: string): void {
-      db.delete(projects).where(eq(projects.id, id)).run();
+    async remove(id: string): Promise<void> {
+      await db.delete(projects).where(eq(projects.id, id)).run();
     },
   };
 }

--- a/src/core/relation.ts
+++ b/src/core/relation.ts
@@ -6,19 +6,19 @@ import type { AddRelation, ObservationRelation } from "../types.ts";
 
 export function createRelationStore(db: ObsxaDB) {
   return {
-    add(input: AddRelation): ObservationRelation {
+    async add(input: AddRelation): Promise<ObservationRelation> {
       if (input.fromObservationId === input.toObservationId) {
         throw new Error("Cannot create self-reference relation");
       }
 
-      const fromObservation = db
+      const fromObservation = await db
         .select({ id: observations.id, projectId: observations.projectId })
         .from(observations)
         .where(eq(observations.id, input.fromObservationId))
         .get();
       if (!fromObservation) throw new Error(`Observation #${input.fromObservationId} not found`);
 
-      const toObservation = db
+      const toObservation = await db
         .select({ id: observations.id, projectId: observations.projectId })
         .from(observations)
         .where(eq(observations.id, input.toObservationId))
@@ -36,7 +36,7 @@ export function createRelationStore(db: ObsxaDB) {
         throw new Error("Relation confidence must be between 0 and 100");
       }
 
-      const existing = db
+      const existing = await db
         .select()
         .from(observationRelations)
         .where(
@@ -49,7 +49,7 @@ export function createRelationStore(db: ObsxaDB) {
         .get();
       if (existing) return toRelation(existing);
 
-      const row = db
+      const row = await db
         .insert(observationRelations)
         .values({
           fromObservationId: input.fromObservationId,
@@ -64,22 +64,23 @@ export function createRelationStore(db: ObsxaDB) {
       return toRelation(row);
     },
 
-    list(observationId: number): ObservationRelation[] {
-      return db
-        .select()
-        .from(observationRelations)
-        .where(
-          or(
-            eq(observationRelations.fromObservationId, observationId),
-            eq(observationRelations.toObservationId, observationId),
-          ),
-        )
-        .all()
-        .map(toRelation);
+    async list(observationId: number): Promise<ObservationRelation[]> {
+      return (
+        await db
+          .select()
+          .from(observationRelations)
+          .where(
+            or(
+              eq(observationRelations.fromObservationId, observationId),
+              eq(observationRelations.toObservationId, observationId),
+            ),
+          )
+          .all()
+      ).map(toRelation);
     },
 
-    remove(id: number): void {
-      db.delete(observationRelations).where(eq(observationRelations.id, id)).run();
+    async remove(id: number): Promise<void> {
+      await db.delete(observationRelations).where(eq(observationRelations.id, id)).run();
     },
   };
 }

--- a/src/core/relation.ts
+++ b/src/core/relation.ts
@@ -49,17 +49,38 @@ export function createRelationStore(db: ObsxaDB) {
         .get();
       if (existing) return toRelation(existing);
 
-      const row = await db
-        .insert(observationRelations)
-        .values({
-          fromObservationId: input.fromObservationId,
-          toObservationId: input.toObservationId,
-          type: input.type,
-          confidence,
-          notes: input.notes,
-        })
-        .returning()
-        .get();
+      let row: typeof observationRelations.$inferSelect;
+      try {
+        row = await db
+          .insert(observationRelations)
+          .values({
+            fromObservationId: input.fromObservationId,
+            toObservationId: input.toObservationId,
+            type: input.type,
+            confidence,
+            notes: input.notes,
+          })
+          .returning()
+          .get();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!/unique|constraint/i.test(message)) {
+          throw error;
+        }
+        const concurrent = await db
+          .select()
+          .from(observationRelations)
+          .where(
+            and(
+              eq(observationRelations.fromObservationId, input.fromObservationId),
+              eq(observationRelations.toObservationId, input.toObservationId),
+              eq(observationRelations.type, input.type),
+            ),
+          )
+          .get();
+        if (!concurrent) throw error;
+        return toRelation(concurrent);
+      }
 
       return toRelation(row);
     },

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,4 +1,4 @@
-import type Database from "better-sqlite3";
+import type { Client } from "@libsql/client";
 import { parseTags } from "./mappers.ts";
 import type {
   Observation,
@@ -40,9 +40,9 @@ function rowToObservation(row: Record<string, unknown>): Observation {
   };
 }
 
-export function createSearchStore(sqlite: Database.Database) {
+export function createSearchStore(client: Client) {
   return {
-    search(query: string, projectId?: string, limit = 50): SearchResult[] {
+    async search(query: string, projectId?: string, limit = 50): Promise<SearchResult[]> {
       try {
         let sql = `
           SELECT o.*, fts.rank
@@ -50,7 +50,7 @@ export function createSearchStore(sqlite: Database.Database) {
           JOIN observations_fts fts ON o.id = fts.rowid
           WHERE observations_fts MATCH ?
         `;
-        const params: unknown[] = [query];
+        const params: Array<string | number> = [query];
 
         if (projectId) {
           sql += " AND o.project_id = ?";
@@ -60,7 +60,8 @@ export function createSearchStore(sqlite: Database.Database) {
         sql += " ORDER BY fts.rank LIMIT ?";
         params.push(limit);
 
-        const rows = sqlite.prepare(sql).all(...params) as Record<string, unknown>[];
+        const result = await client.execute({ sql, args: params });
+        const rows = result.rows as Record<string, unknown>[];
         return rows.map((row, index) => ({ observation: rowToObservation(row), rank: index + 1 }));
       } catch {
         let sql = `
@@ -69,7 +70,7 @@ export function createSearchStore(sqlite: Database.Database) {
           WHERE (title LIKE ? OR description LIKE ? OR tags LIKE ?)
         `;
         const like = `%${query}%`;
-        const params: unknown[] = [like, like, like];
+        const params: Array<string | number> = [like, like, like];
 
         if (projectId) {
           sql += " AND project_id = ?";
@@ -79,7 +80,8 @@ export function createSearchStore(sqlite: Database.Database) {
         sql += " ORDER BY created_at DESC LIMIT ?";
         params.push(limit);
 
-        const rows = sqlite.prepare(sql).all(...params) as Record<string, unknown>[];
+        const result = await client.execute({ sql, args: params });
+        const rows = result.rows as Record<string, unknown>[];
         return rows.map((row, index) => ({ observation: rowToObservation(row), rank: index + 1 }));
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,14 @@ function toLibsqlUrl(dbPath: string): string {
   return `file:${dbPath}`;
 }
 
+function toBackupDbPath(dbPath: string): string | null {
+  if (dbPath === ":memory:") return null;
+  if (/^(?:libsql:|https?:|wss?:)/.test(dbPath)) return null;
+  if (dbPath.startsWith("file://")) return fileURLToPath(dbPath);
+  if (dbPath.startsWith("file:")) return dbPath.slice(5);
+  return dbPath;
+}
+
 const CUSTOM_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_observations_project ON observations(project_id)",
   "CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status)",
@@ -203,7 +211,9 @@ export async function createObsxa(
     backupDir: options.backupDir,
   };
 
-  const client = createClient({ url: toLibsqlUrl(options.db) });
+  const dbUrl = toLibsqlUrl(options.db);
+  const backupDbPath = toBackupDbPath(options.db);
+  const client = createClient({ url: dbUrl });
   try {
     try {
       await client.execute("PRAGMA journal_mode = WAL");
@@ -227,9 +237,9 @@ export async function createObsxa(
       );
     }
 
-    if (needsMigration && shouldBackup(options.db, resolved.autoBackup)) {
-      const backupPath = makeBackupPath(options.db, resolved.backupDir);
-      backupDatabase(options.db, backupPath);
+    if (backupDbPath && needsMigration && shouldBackup(backupDbPath, resolved.autoBackup)) {
+      const backupPath = makeBackupPath(backupDbPath, resolved.backupDir);
+      backupDatabase(backupDbPath, backupPath);
     }
 
     const db: ObsxaDB = drizzle({ client });
@@ -241,11 +251,10 @@ export async function createObsxa(
     for (const statement of CUSTOM_SQL) {
       await client.execute(statement);
     }
-    try {
-      for (const statement of FTS_SQL) {
-        await client.execute(statement);
-      }
-    } catch {}
+    for (const statement of FTS_SQL) {
+      await client.execute(statement);
+    }
+    await client.execute("INSERT INTO observations_fts(observations_fts) VALUES('rebuild')");
 
     return {
       project: createProjectStore(db),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql/node";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { createAnalysisStore } from "./core/analysis.ts";
 import { createClusterStore } from "./core/cluster.ts";
 import { createDedupStore } from "./core/dedup.ts";
@@ -12,6 +12,7 @@ import { createProjectStore } from "./core/project.ts";
 import { createRelationStore } from "./core/relation.ts";
 import { createSearchStore } from "./core/search.ts";
 import { backupDatabase } from "./backup.ts";
+import type { ObsxaDB } from "./core/db.ts";
 import type { ObsxaOptions } from "./types.ts";
 
 const SCHEMA_VERSION = 1;
@@ -67,8 +68,8 @@ function findMigrationsFolder(): string {
   throw new Error("Cannot find drizzle migrations folder");
 }
 
-function ensureMetaTable(sqlite: Database.Database): void {
-  sqlite.exec(`
+async function ensureMetaTable(client: Client): Promise<void> {
+  await client.execute(`
     CREATE TABLE IF NOT EXISTS obsxa_meta (
       key TEXT PRIMARY KEY NOT NULL,
       value TEXT NOT NULL,
@@ -77,23 +78,24 @@ function ensureMetaTable(sqlite: Database.Database): void {
   `);
 }
 
-function getSchemaVersion(sqlite: Database.Database): number | null {
-  const row = sqlite.prepare("SELECT value FROM obsxa_meta WHERE key = ?").get("schema_version") as
-    | { value?: string }
-    | undefined;
+async function getSchemaVersion(client: Client): Promise<number | null> {
+  const result = await client.execute({
+    sql: "SELECT value FROM obsxa_meta WHERE key = ?",
+    args: ["schema_version"],
+  });
+  const row = result.rows[0] as { value?: unknown } | undefined;
   if (!row?.value) return null;
-  const parsed = Number.parseInt(row.value, 10);
+  const parsed = Number.parseInt(String(row.value), 10);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function setSchemaVersion(sqlite: Database.Database, version: number): void {
-  sqlite
-    .prepare(
-      `INSERT INTO obsxa_meta (key, value, updated_at)
+async function setSchemaVersion(client: Client, version: number): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO obsxa_meta (key, value, updated_at)
      VALUES (?, ?, strftime('%s', 'now'))
      ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`,
-    )
-    .run("schema_version", String(version));
+    args: ["schema_version", String(version)],
+  });
 }
 
 function shouldBackup(dbPath: string, autoBackup: boolean): boolean {
@@ -117,52 +119,55 @@ function makeBackupPath(dbPath: string, backupDir?: string): string {
   return `${dbPath}.bak.${stamp}`;
 }
 
-const CUSTOM_SQL = `
-CREATE INDEX IF NOT EXISTS idx_observations_project ON observations(project_id);
-CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
-CREATE INDEX IF NOT EXISTS idx_observations_type ON observations(type);
-CREATE INDEX IF NOT EXISTS idx_observations_source_type ON observations(source_type);
-CREATE INDEX IF NOT EXISTS idx_observations_triage ON observations(triage_score);
-CREATE INDEX IF NOT EXISTS idx_rel_from ON observation_relations(from_observation_id);
-CREATE INDEX IF NOT EXISTS idx_rel_to ON observation_relations(to_observation_id);
-CREATE INDEX IF NOT EXISTS idx_rel_type ON observation_relations(type);
-CREATE INDEX IF NOT EXISTS idx_observation_status_events_observation ON observation_status_events(observation_id);
-CREATE INDEX IF NOT EXISTS idx_clusters_project ON clusters(project_id);
-CREATE INDEX IF NOT EXISTS idx_cluster_members_cluster ON cluster_members(cluster_id);
-CREATE INDEX IF NOT EXISTS idx_cluster_members_observation ON cluster_members(observation_id);
-CREATE INDEX IF NOT EXISTS idx_duplicate_candidates_project ON duplicate_candidates(project_id);
-CREATE INDEX IF NOT EXISTS idx_duplicate_candidates_status ON duplicate_candidates(status);
-CREATE INDEX IF NOT EXISTS idx_duplicate_candidate_events_candidate ON duplicate_candidate_events(candidate_id);
-CREATE INDEX IF NOT EXISTS idx_observation_merges_project ON observation_merges(project_id);
-CREATE INDEX IF NOT EXISTS idx_observation_edits_observation ON observation_edits(observation_id);
-`;
+function toLibsqlUrl(dbPath: string): string {
+  if (dbPath === ":memory:") return dbPath;
+  if (/^(?:file:|libsql:|https?:|wss?:)/.test(dbPath)) return dbPath;
+  return `file:${dbPath}`;
+}
 
-const FTS_SQL = `
-CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
-  title,
-  description,
-  tags,
-  content='observations',
-  content_rowid='id'
-);
+const CUSTOM_SQL = [
+  "CREATE INDEX IF NOT EXISTS idx_observations_project ON observations(project_id)",
+  "CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status)",
+  "CREATE INDEX IF NOT EXISTS idx_observations_type ON observations(type)",
+  "CREATE INDEX IF NOT EXISTS idx_observations_source_type ON observations(source_type)",
+  "CREATE INDEX IF NOT EXISTS idx_observations_triage ON observations(triage_score)",
+  "CREATE INDEX IF NOT EXISTS idx_rel_from ON observation_relations(from_observation_id)",
+  "CREATE INDEX IF NOT EXISTS idx_rel_to ON observation_relations(to_observation_id)",
+  "CREATE INDEX IF NOT EXISTS idx_rel_type ON observation_relations(type)",
+  "CREATE INDEX IF NOT EXISTS idx_observation_status_events_observation ON observation_status_events(observation_id)",
+  "CREATE INDEX IF NOT EXISTS idx_clusters_project ON clusters(project_id)",
+  "CREATE INDEX IF NOT EXISTS idx_cluster_members_cluster ON cluster_members(cluster_id)",
+  "CREATE INDEX IF NOT EXISTS idx_cluster_members_observation ON cluster_members(observation_id)",
+  "CREATE INDEX IF NOT EXISTS idx_duplicate_candidates_project ON duplicate_candidates(project_id)",
+  "CREATE INDEX IF NOT EXISTS idx_duplicate_candidates_status ON duplicate_candidates(status)",
+  "CREATE INDEX IF NOT EXISTS idx_duplicate_candidate_events_candidate ON duplicate_candidate_events(candidate_id)",
+  "CREATE INDEX IF NOT EXISTS idx_observation_merges_project ON observation_merges(project_id)",
+  "CREATE INDEX IF NOT EXISTS idx_observation_edits_observation ON observation_edits(observation_id)",
+];
 
-CREATE TRIGGER IF NOT EXISTS observations_fts_ai AFTER INSERT ON observations BEGIN
-  INSERT INTO observations_fts(rowid, title, description, tags)
-  VALUES (NEW.id, NEW.title, NEW.description, NEW.tags);
-END;
-
-CREATE TRIGGER IF NOT EXISTS observations_fts_ad AFTER DELETE ON observations BEGIN
-  INSERT INTO observations_fts(observations_fts, rowid, title, description, tags)
-  VALUES('delete', OLD.id, OLD.title, OLD.description, OLD.tags);
-END;
-
-CREATE TRIGGER IF NOT EXISTS observations_fts_au AFTER UPDATE ON observations BEGIN
-  INSERT INTO observations_fts(observations_fts, rowid, title, description, tags)
-  VALUES('delete', OLD.id, OLD.title, OLD.description, OLD.tags);
-  INSERT INTO observations_fts(rowid, title, description, tags)
-  VALUES (NEW.id, NEW.title, NEW.description, NEW.tags);
-END;
-`;
+const FTS_SQL = [
+  `CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
+    title,
+    description,
+    tags,
+    content='observations',
+    content_rowid='id'
+  )`,
+  `CREATE TRIGGER IF NOT EXISTS observations_fts_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observations_fts(rowid, title, description, tags)
+    VALUES (NEW.id, NEW.title, NEW.description, NEW.tags);
+  END`,
+  `CREATE TRIGGER IF NOT EXISTS observations_fts_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, description, tags)
+    VALUES('delete', OLD.id, OLD.title, OLD.description, OLD.tags);
+  END`,
+  `CREATE TRIGGER IF NOT EXISTS observations_fts_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, description, tags)
+    VALUES('delete', OLD.id, OLD.title, OLD.description, OLD.tags);
+    INSERT INTO observations_fts(rowid, title, description, tags)
+    VALUES (NEW.id, NEW.title, NEW.description, NEW.tags);
+  END`,
+];
 
 /** Observation database instance with all store modules attached. Call `.close()` when done. */
 export interface ObsxaInstance {
@@ -173,7 +178,7 @@ export interface ObsxaInstance {
   dedup: ReturnType<typeof createDedupStore>;
   search: ReturnType<typeof createSearchStore>;
   analysis: ReturnType<typeof createAnalysisStore>;
-  close(): void;
+  close(): Promise<void>;
 }
 
 /**
@@ -184,24 +189,30 @@ export interface ObsxaInstance {
  *
  * @example
  * ```ts
- * const obsxa = createObsxa({ db: './research.db' })
- * obsxa.observation.add({ projectId: 'my-project', title: 'Pattern found', source: 'scan' })
- * obsxa.close()
+ * const obsxa = await createObsxa({ db: './research.db' })
+ * await obsxa.observation.add({ projectId: 'my-project', title: 'Pattern found', source: 'scan' })
+ * await obsxa.close()
  * ```
  */
-export function createObsxa(options: ObsxaOptions = { db: "./obsxa.db" }): ObsxaInstance {
+export async function createObsxa(
+  options: ObsxaOptions = { db: "./obsxa.db" },
+): Promise<ObsxaInstance> {
   const resolved = {
     autoMigrate: options.autoMigrate ?? true,
     autoBackup: options.autoBackup ?? true,
     backupDir: options.backupDir,
   };
 
-  const sqlite = new Database(options.db);
-  sqlite.pragma("journal_mode = WAL");
-  sqlite.pragma("foreign_keys = ON");
+  const client = createClient({ url: toLibsqlUrl(options.db) });
+  try {
+    await client.execute("PRAGMA journal_mode = WAL");
+  } catch {}
+  try {
+    await client.execute("PRAGMA foreign_keys = ON");
+  } catch {}
 
-  ensureMetaTable(sqlite);
-  const beforeVersion = getSchemaVersion(sqlite);
+  await ensureMetaTable(client);
+  const beforeVersion = await getSchemaVersion(client);
   if (beforeVersion !== null && beforeVersion > SCHEMA_VERSION) {
     throw new Error(
       `Database schema version ${beforeVersion} is newer than supported ${SCHEMA_VERSION}. Upgrade obsxa package.`,
@@ -220,15 +231,19 @@ export function createObsxa(options: ObsxaOptions = { db: "./obsxa.db" }): Obsxa
     backupDatabase(options.db, backupPath);
   }
 
-  const db = drizzle(sqlite);
+  const db: ObsxaDB = drizzle({ client });
   if (needsMigration) {
-    migrate(db, { migrationsFolder: findMigrationsFolder() });
-    setSchemaVersion(sqlite, SCHEMA_VERSION);
+    await migrate(db, { migrationsFolder: findMigrationsFolder() });
+    await setSchemaVersion(client, SCHEMA_VERSION);
   }
 
-  sqlite.exec(CUSTOM_SQL);
+  for (const statement of CUSTOM_SQL) {
+    await client.execute(statement);
+  }
   try {
-    sqlite.exec(FTS_SQL);
+    for (const statement of FTS_SQL) {
+      await client.execute(statement);
+    }
   } catch {}
 
   return {
@@ -237,11 +252,11 @@ export function createObsxa(options: ObsxaOptions = { db: "./obsxa.db" }): Obsxa
     relation: createRelationStore(db),
     cluster: createClusterStore(db),
     dedup: createDedupStore(db),
-    search: createSearchStore(sqlite),
+    search: createSearchStore(client),
     analysis: createAnalysisStore(db),
 
-    close() {
-      sqlite.close();
+    async close() {
+      client.close();
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,10 +79,17 @@ async function ensureMetaTable(client: Client): Promise<void> {
 }
 
 async function getSchemaVersion(client: Client): Promise<number | null> {
-  const result = await client.execute({
-    sql: "SELECT value FROM obsxa_meta WHERE key = ?",
-    args: ["schema_version"],
-  });
+  let result;
+  try {
+    result = await client.execute({
+      sql: "SELECT value FROM obsxa_meta WHERE key = ?",
+      args: ["schema_version"],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/no such table:\s*obsxa_meta/i.test(message)) return null;
+    throw error;
+  }
   const row = result.rows[0] as { value?: unknown } | undefined;
   if (!row?.value) return null;
   const parsed = Number.parseInt(String(row.value), 10);
@@ -222,7 +229,6 @@ export async function createObsxa(
       await client.execute("PRAGMA foreign_keys = ON");
     } catch {}
 
-    await ensureMetaTable(client);
     const beforeVersion = await getSchemaVersion(client);
     if (beforeVersion !== null && beforeVersion > SCHEMA_VERSION) {
       throw new Error(
@@ -242,6 +248,8 @@ export async function createObsxa(
       backupDatabase(backupDbPath, backupPath);
     }
 
+    await ensureMetaTable(client);
+
     const db: ObsxaDB = drizzle({ client });
     if (needsMigration) {
       await migrate(db, { migrationsFolder: findMigrationsFolder() });
@@ -251,10 +259,17 @@ export async function createObsxa(
     for (const statement of CUSTOM_SQL) {
       await client.execute(statement);
     }
+    const ftsExists = await client.execute({
+      sql: "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1",
+      args: ["table", "observations_fts"],
+    });
+
     for (const statement of FTS_SQL) {
       await client.execute(statement);
     }
-    await client.execute("INSERT INTO observations_fts(observations_fts) VALUES('rebuild')");
+    if (ftsExists.rows.length === 0 || needsMigration) {
+      await client.execute("INSERT INTO observations_fts(observations_fts) VALUES('rebuild')");
+    }
 
     return {
       project: createProjectStore(db),

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,58 +205,63 @@ export async function createObsxa(
 
   const client = createClient({ url: toLibsqlUrl(options.db) });
   try {
-    await client.execute("PRAGMA journal_mode = WAL");
-  } catch {}
-  try {
-    await client.execute("PRAGMA foreign_keys = ON");
-  } catch {}
+    try {
+      await client.execute("PRAGMA journal_mode = WAL");
+    } catch {}
+    try {
+      await client.execute("PRAGMA foreign_keys = ON");
+    } catch {}
 
-  await ensureMetaTable(client);
-  const beforeVersion = await getSchemaVersion(client);
-  if (beforeVersion !== null && beforeVersion > SCHEMA_VERSION) {
-    throw new Error(
-      `Database schema version ${beforeVersion} is newer than supported ${SCHEMA_VERSION}. Upgrade obsxa package.`,
-    );
-  }
+    await ensureMetaTable(client);
+    const beforeVersion = await getSchemaVersion(client);
+    if (beforeVersion !== null && beforeVersion > SCHEMA_VERSION) {
+      throw new Error(
+        `Database schema version ${beforeVersion} is newer than supported ${SCHEMA_VERSION}. Upgrade obsxa package.`,
+      );
+    }
 
-  const needsMigration = beforeVersion === null || beforeVersion < SCHEMA_VERSION;
-  if (needsMigration && !resolved.autoMigrate) {
-    throw new Error(
-      `Database schema version ${beforeVersion ?? 0} requires migration to ${SCHEMA_VERSION}, but autoMigrate is disabled.`,
-    );
-  }
+    const needsMigration = beforeVersion === null || beforeVersion < SCHEMA_VERSION;
+    if (needsMigration && !resolved.autoMigrate) {
+      throw new Error(
+        `Database schema version ${beforeVersion ?? 0} requires migration to ${SCHEMA_VERSION}, but autoMigrate is disabled.`,
+      );
+    }
 
-  if (needsMigration && shouldBackup(options.db, resolved.autoBackup)) {
-    const backupPath = makeBackupPath(options.db, resolved.backupDir);
-    backupDatabase(options.db, backupPath);
-  }
+    if (needsMigration && shouldBackup(options.db, resolved.autoBackup)) {
+      const backupPath = makeBackupPath(options.db, resolved.backupDir);
+      backupDatabase(options.db, backupPath);
+    }
 
-  const db: ObsxaDB = drizzle({ client });
-  if (needsMigration) {
-    await migrate(db, { migrationsFolder: findMigrationsFolder() });
-    await setSchemaVersion(client, SCHEMA_VERSION);
-  }
+    const db: ObsxaDB = drizzle({ client });
+    if (needsMigration) {
+      await migrate(db, { migrationsFolder: findMigrationsFolder() });
+      await setSchemaVersion(client, SCHEMA_VERSION);
+    }
 
-  for (const statement of CUSTOM_SQL) {
-    await client.execute(statement);
-  }
-  try {
-    for (const statement of FTS_SQL) {
+    for (const statement of CUSTOM_SQL) {
       await client.execute(statement);
     }
-  } catch {}
+    try {
+      for (const statement of FTS_SQL) {
+        await client.execute(statement);
+      }
+    } catch {}
 
-  return {
-    project: createProjectStore(db),
-    observation: createObservationStore(db),
-    relation: createRelationStore(db),
-    cluster: createClusterStore(db),
-    dedup: createDedupStore(db),
-    search: createSearchStore(client),
-    analysis: createAnalysisStore(db),
+    return {
+      project: createProjectStore(db),
+      observation: createObservationStore(db),
+      relation: createRelationStore(db),
+      cluster: createClusterStore(db),
+      dedup: createDedupStore(db),
+      search: createSearchStore(client),
+      analysis: createAnalysisStore(db),
 
-    async close() {
-      client.close();
-    },
-  };
+      async close() {
+        client.close();
+      },
+    };
+  } catch (error) {
+    client.close();
+    throw error;
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,20 +8,23 @@ import { createObsxa, type ObsxaInstance } from "../src/index.ts";
 
 async function setSchemaVersion(dbPath: string, version: number): Promise<void> {
   const client = createClient({ url: `file:${dbPath}` });
-  await client.execute(`
-    CREATE TABLE IF NOT EXISTS obsxa_meta (
-      key TEXT PRIMARY KEY NOT NULL,
-      value TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  await client.execute({
-    sql: `INSERT INTO obsxa_meta (key, value, updated_at)
-      VALUES (?, ?, strftime('%s', 'now'))
-      ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`,
-    args: ["schema_version", String(version)],
-  });
-  client.close();
+  try {
+    await client.execute(`
+      CREATE TABLE IF NOT EXISTS obsxa_meta (
+        key TEXT PRIMARY KEY NOT NULL,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    await client.execute({
+      sql: `INSERT INTO obsxa_meta (key, value, updated_at)
+        VALUES (?, ?, strftime('%s', 'now'))
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`,
+      args: ["schema_version", String(version)],
+    });
+  } finally {
+    client.close();
+  }
 }
 
 describe("obsxa", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,28 @@
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createClient } from "@libsql/client/node";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import Database from "better-sqlite3";
 import { backupDatabase, restoreDatabase } from "../src/backup.ts";
 import { createObsxa, type ObsxaInstance } from "../src/index.ts";
+
+async function setSchemaVersion(dbPath: string, version: number): Promise<void> {
+  const client = createClient({ url: `file:${dbPath}` });
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS obsxa_meta (
+      key TEXT PRIMARY KEY NOT NULL,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  await client.execute({
+    sql: `INSERT INTO obsxa_meta (key, value, updated_at)
+      VALUES (?, ?, strftime('%s', 'now'))
+      ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`,
+    args: ["schema_version", String(version)],
+  });
+  client.close();
+}
 
 describe("obsxa", () => {
   let dbDir: string;
@@ -12,30 +30,30 @@ describe("obsxa", () => {
   let obsxa: ObsxaInstance;
   let obsxaClosed: boolean;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbDir = mkdtempSync(join(tmpdir(), "obsxa-"));
     dbPath = join(dbDir, "test.db");
-    obsxa = createObsxa({ db: dbPath });
+    obsxa = await createObsxa({ db: dbPath });
     obsxaClosed = false;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (!obsxaClosed) {
-      obsxa.close();
+      await obsxa.close();
       obsxaClosed = true;
     }
     rmSync(dbDir, { recursive: true, force: true });
   });
 
-  it("creates project", () => {
-    const project = obsxa.project.add({ id: "p1", name: "Obs Project" });
+  it("creates project", async () => {
+    const project = await obsxa.project.add({ id: "p1", name: "Obs Project" });
     expect(project.id).toBe("p1");
-    expect(obsxa.project.get("p1")?.name).toBe("Obs Project");
+    expect((await obsxa.project.get("p1"))?.name).toBe("Obs Project");
   });
 
-  it("adds observation", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const observation = obsxa.observation.add({
+  it("adds observation", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const observation = await obsxa.observation.add({
       projectId: "p1",
       title: "Noticed repeated modulo residue",
       source: "E001",
@@ -45,25 +63,25 @@ describe("obsxa", () => {
     expect(observation.tags).toContain("mod");
   });
 
-  it("lists observations with filters", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const o1 = obsxa.observation.add({
+  it("lists observations with filters", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const o1 = await obsxa.observation.add({
       projectId: "p1",
       title: "A",
       source: "E1",
       type: "pattern",
     });
-    obsxa.observation.add({ projectId: "p1", title: "B", source: "E2", type: "anomaly" });
-    obsxa.observation.dismiss(o1.id, { reasonCode: "noise" });
-    expect(obsxa.observation.list("p1")).toHaveLength(2);
-    expect(obsxa.observation.list("p1", { status: "dismissed" })).toHaveLength(1);
-    expect(obsxa.observation.list("p1", { type: "anomaly" })).toHaveLength(1);
+    await obsxa.observation.add({ projectId: "p1", title: "B", source: "E2", type: "anomaly" });
+    await obsxa.observation.dismiss(o1.id, { reasonCode: "noise" });
+    expect(await obsxa.observation.list("p1")).toHaveLength(2);
+    expect(await obsxa.observation.list("p1", { status: "dismissed" })).toHaveLength(1);
+    expect(await obsxa.observation.list("p1", { type: "anomaly" })).toHaveLength(1);
   });
 
-  it("updates observation", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const updated = obsxa.observation.update(obs.id, {
+  it("updates observation", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const updated = await obsxa.observation.update(obs.id, {
       title: "A+",
       confidence: 88,
       tags: ["updated"],
@@ -73,58 +91,58 @@ describe("obsxa", () => {
     expect(updated.updatedAt).not.toBeNull();
   });
 
-  it("dismisses active observation", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const dismissed = obsxa.observation.dismiss(obs.id, {
+  it("dismisses active observation", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const dismissed = await obsxa.observation.dismiss(obs.id, {
       reasonCode: "noise",
       reasonNote: "No signal",
     });
     expect(dismissed.status).toBe("dismissed");
-    const transitions = obsxa.observation.transitions(obs.id);
+    const transitions = await obsxa.observation.transitions(obs.id);
     expect(transitions).toHaveLength(1);
     expect(transitions[0]?.reasonCode).toBe("noise");
   });
 
-  it("archives active observation with reason", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const archived = obsxa.observation.archive(obs.id, { reasonCode: "manual_review" });
+  it("archives active observation with reason", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const archived = await obsxa.observation.archive(obs.id, { reasonCode: "manual_review" });
     expect(archived.status).toBe("archived");
     expect(archived.archivedReasonCode).toBe("manual_review");
   });
 
-  it("increments observation frequency", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const bumped = obsxa.observation.incrementFrequency(obs.id);
+  it("increments observation frequency", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const bumped = await obsxa.observation.incrementFrequency(obs.id);
     expect(bumped.frequency).toBe(2);
     expect(bumped.updatedAt).not.toBeNull();
   });
 
-  it("promotes observation", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const promoted = obsxa.observation.promote(obs.id, "hypxa:p1:3");
+  it("promotes observation", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const promoted = await obsxa.observation.promote(obs.id, "hypxa:p1:3");
     expect(promoted.status).toBe("promoted");
     expect(promoted.promotedTo).toBe("hypxa:p1:3");
   });
 
-  it("adds relations and rejects self/duplicate", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const a = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const b = obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
-    const relation = obsxa.relation.add({
+  it("adds relations and rejects self/duplicate", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const a = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const b = await obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
+    const relation = await obsxa.relation.add({
       fromObservationId: a.id,
       toObservationId: b.id,
       type: "supports",
     });
     expect(relation.id).toBeGreaterThan(0);
     expect(relation.confidence).toBe(100);
-    expect(() =>
+    await expect(
       obsxa.relation.add({ fromObservationId: a.id, toObservationId: a.id, type: "supports" }),
-    ).toThrow();
-    const dup = obsxa.relation.add({
+    ).rejects.toThrow();
+    const dup = await obsxa.relation.add({
       fromObservationId: a.id,
       toObservationId: b.id,
       type: "supports",
@@ -132,12 +150,12 @@ describe("obsxa", () => {
     expect(dup.id).toBe(relation.id);
   });
 
-  it("stores relation confidence and notes", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const a = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const b = obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
+  it("stores relation confidence and notes", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const a = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const b = await obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
 
-    const relation = obsxa.relation.add({
+    const relation = await obsxa.relation.add({
       fromObservationId: a.id,
       toObservationId: b.id,
       type: "same_signal_as",
@@ -149,87 +167,109 @@ describe("obsxa", () => {
     expect(relation.notes).toBe("Same source family");
   });
 
-  it("handles clusters and membership", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const o1 = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
-    const o2 = obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
-    const cluster = obsxa.cluster.add({ projectId: "p1", name: "Signals" });
-    const m1 = obsxa.cluster.addMember(cluster.id, o1.id);
-    const m2 = obsxa.cluster.addMember(cluster.id, o1.id);
-    obsxa.cluster.addMember(cluster.id, o2.id);
+  it("handles clusters and membership", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const o1 = await obsxa.observation.add({ projectId: "p1", title: "A", source: "E1" });
+    const o2 = await obsxa.observation.add({ projectId: "p1", title: "B", source: "E2" });
+    const cluster = await obsxa.cluster.add({ projectId: "p1", name: "Signals" });
+    const m1 = await obsxa.cluster.addMember(cluster.id, o1.id);
+    const m2 = await obsxa.cluster.addMember(cluster.id, o1.id);
+    await obsxa.cluster.addMember(cluster.id, o2.id);
     expect(m2.id).toBe(m1.id);
-    expect(obsxa.cluster.list("p1")).toHaveLength(1);
-    expect(obsxa.cluster.listMembers(cluster.id)).toHaveLength(2);
+    expect(await obsxa.cluster.list("p1")).toHaveLength(1);
+    expect(await obsxa.cluster.listMembers(cluster.id)).toHaveLength(2);
   });
 
-  it("searches observations via fts and fallback", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({
+  it("searches observations via fts and fallback", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({
       projectId: "p1",
       title: "Quantum anomaly",
       description: "Euler's signal",
       source: "scan:1",
       tags: ["quantum"],
     });
-    const fts = obsxa.search.search("Quantum", "p1");
+    const fts = await obsxa.search.search("Quantum", "p1");
     expect(fts).toHaveLength(1);
-    const fallback = obsxa.search.search("'", "p1");
+    const fallback = await obsxa.search.search("'", "p1");
     expect(fallback.length).toBeGreaterThan(0);
   });
 
-  it("computes analysis stats, frequent, isolated, unpromoted", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const a = obsxa.observation.add({ projectId: "p1", title: "A", source: "E1", type: "pattern" });
-    const b = obsxa.observation.add({ projectId: "p1", title: "B", source: "E2", type: "anomaly" });
-    const c = obsxa.observation.add({
+  it("computes analysis stats, frequent, isolated, unpromoted", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const a = await obsxa.observation.add({
+      projectId: "p1",
+      title: "A",
+      source: "E1",
+      type: "pattern",
+    });
+    const b = await obsxa.observation.add({
+      projectId: "p1",
+      title: "B",
+      source: "E2",
+      type: "anomaly",
+    });
+    const c = await obsxa.observation.add({
       projectId: "p1",
       title: "C",
       source: "E3",
       type: "measurement",
     });
-    obsxa.observation.incrementFrequency(a.id);
-    obsxa.observation.promote(b.id, "hypxa:p1:4");
-    obsxa.relation.add({ fromObservationId: a.id, toObservationId: b.id, type: "supports" });
+    await obsxa.observation.incrementFrequency(a.id);
+    await obsxa.observation.promote(b.id, "hypxa:p1:4");
+    await obsxa.relation.add({ fromObservationId: a.id, toObservationId: b.id, type: "supports" });
 
-    const stats = obsxa.analysis.stats("p1");
+    const stats = await obsxa.analysis.stats("p1");
     expect(stats.total).toBe(3);
     expect(stats.active).toBe(2);
     expect(stats.promoted).toBe(1);
     expect(stats.byType.measurement).toBe(1);
 
-    const frequent = obsxa.analysis.frequent("p1");
+    const frequent = await obsxa.analysis.frequent("p1");
     expect(frequent).toHaveLength(1);
     expect(frequent[0]?.id).toBe(a.id);
 
-    const isolated = obsxa.analysis.isolated("p1");
+    const isolated = await obsxa.analysis.isolated("p1");
     expect(isolated.map((o) => o.id)).toContain(c.id);
 
-    const unpromoted = obsxa.analysis.unpromoted("p1");
+    const unpromoted = await obsxa.analysis.unpromoted("p1");
     expect(unpromoted.map((o) => o.id)).toContain(a.id);
     expect(unpromoted.map((o) => o.id)).toContain(c.id);
     expect(unpromoted.map((o) => o.id)).not.toContain(b.id);
   });
 
-  it("computes convergent and promoted analysis", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const target = obsxa.observation.add({ projectId: "p1", title: "Target", source: "E0" });
-    const s1 = obsxa.observation.add({ projectId: "p1", title: "Support 1", source: "E1" });
-    const s2 = obsxa.observation.add({ projectId: "p1", title: "Support 2", source: "E2" });
-    const promoted = obsxa.observation.add({ projectId: "p1", title: "Promoted", source: "E3" });
-    obsxa.relation.add({ fromObservationId: s1.id, toObservationId: target.id, type: "supports" });
-    obsxa.relation.add({ fromObservationId: s2.id, toObservationId: target.id, type: "supports" });
-    obsxa.observation.promote(promoted.id, "hypxa:p1:8");
+  it("computes convergent and promoted analysis", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const target = await obsxa.observation.add({ projectId: "p1", title: "Target", source: "E0" });
+    const s1 = await obsxa.observation.add({ projectId: "p1", title: "Support 1", source: "E1" });
+    const s2 = await obsxa.observation.add({ projectId: "p1", title: "Support 2", source: "E2" });
+    const promoted = await obsxa.observation.add({
+      projectId: "p1",
+      title: "Promoted",
+      source: "E3",
+    });
+    await obsxa.relation.add({
+      fromObservationId: s1.id,
+      toObservationId: target.id,
+      type: "supports",
+    });
+    await obsxa.relation.add({
+      fromObservationId: s2.id,
+      toObservationId: target.id,
+      type: "supports",
+    });
+    await obsxa.observation.promote(promoted.id, "hypxa:p1:8");
 
-    const convergent = obsxa.analysis.convergent("p1");
+    const convergent = await obsxa.analysis.convergent("p1");
     expect(convergent.map((o) => o.id)).toContain(target.id);
 
-    const promotedList = obsxa.analysis.promoted("p1");
+    const promotedList = await obsxa.analysis.promoted("p1");
     expect(promotedList.map((o) => o.id)).toContain(promoted.id);
   });
 
-  it("computes triage ranking", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const high = obsxa.observation.add({
+  it("computes triage ranking", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const high = await obsxa.observation.add({
       projectId: "p1",
       title: "High signal",
       source: "E1",
@@ -238,7 +278,7 @@ describe("obsxa", () => {
       novelty: 88,
       uncertainty: 10,
     });
-    const low = obsxa.observation.add({
+    const low = await obsxa.observation.add({
       projectId: "p1",
       title: "Weak signal",
       source: "E2",
@@ -247,17 +287,21 @@ describe("obsxa", () => {
       novelty: 20,
       uncertainty: 80,
     });
-    obsxa.relation.add({ fromObservationId: low.id, toObservationId: high.id, type: "supports" });
+    await obsxa.relation.add({
+      fromObservationId: low.id,
+      toObservationId: high.id,
+      type: "supports",
+    });
 
-    const rows = obsxa.analysis.triage("p1", 10, "triage");
+    const rows = await obsxa.analysis.triage("p1", 10, "triage");
     expect(rows).toHaveLength(2);
     expect(rows[0]?.observation.id).toBe(high.id);
     expect(rows[1]?.observation.id).toBe(low.id);
   });
 
-  it("scans duplicate candidates and merges observations", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const a = obsxa.observation.add({
+  it("scans duplicate candidates and merges observations", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const a = await obsxa.observation.add({
       projectId: "p1",
       title: "Repeated modulo residue in bits 12-16",
       description: "Pattern appears in repeated scans",
@@ -265,7 +309,7 @@ describe("obsxa", () => {
       tags: ["bits", "mod"],
       confidence: 70,
     });
-    const b = obsxa.observation.add({
+    const b = await obsxa.observation.add({
       projectId: "p1",
       title: "Repeated modulo residue in bits 12-16",
       description: "Pattern appears in repeated scans",
@@ -274,12 +318,12 @@ describe("obsxa", () => {
       confidence: 90,
     });
 
-    const scan = obsxa.dedup.scan("p1");
+    const scan = await obsxa.dedup.scan("p1");
     expect(scan.checkedPairs).toBe(1);
     expect(scan.candidates.length).toBe(1);
     expect(scan.candidates[0]?.reason).toBe("exact_fingerprint");
 
-    const merged = obsxa.dedup.merge(a.id, b.id, {
+    const merged = await obsxa.dedup.merge(a.id, b.id, {
       confidenceStrategy: "average",
       relationType: "duplicate_of",
       relationConfidence: 99,
@@ -291,28 +335,28 @@ describe("obsxa", () => {
     expect(merged.merged.status).toBe("archived");
     expect(merged.relation?.type).toBe("duplicate_of");
 
-    const openCandidates = obsxa.dedup.candidates("p1", "open");
+    const openCandidates = await obsxa.dedup.candidates("p1", "open");
     expect(openCandidates).toHaveLength(0);
-    const resolvedCandidates = obsxa.dedup.candidates("p1", "resolved");
+    const resolvedCandidates = await obsxa.dedup.candidates("p1", "resolved");
     expect(resolvedCandidates).toHaveLength(1);
   });
 
-  it("reviews duplicate candidates and records decision event", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({ projectId: "p1", title: "A", description: "x", source: "E1" });
-    obsxa.observation.add({ projectId: "p1", title: "A", description: "x", source: "E2" });
-    const scan = obsxa.dedup.scan("p1");
+  it("reviews duplicate candidates and records decision event", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({ projectId: "p1", title: "A", description: "x", source: "E1" });
+    await obsxa.observation.add({ projectId: "p1", title: "A", description: "x", source: "E2" });
+    const scan = await obsxa.dedup.scan("p1");
     const candidate = scan.candidates[0];
     expect(candidate).toBeDefined();
 
-    const review = obsxa.dedup.review(candidate!.id, "dismissed", "false positive");
+    const review = await obsxa.dedup.review(candidate!.id, "dismissed", "false positive");
     expect(review.candidate.status).toBe("dismissed");
     expect(review.event.reason).toBe("false positive");
   });
 
-  it("stores and retrieves observation context", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({
+  it("stores and retrieves observation context", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({
       projectId: "p1",
       title: "Sensor reading",
       source: "station-7",
@@ -328,23 +372,23 @@ describe("obsxa", () => {
     expect(parsed.instrument).toBe("DHT22");
     expect(parsed.temperature).toBe(22.5);
 
-    const fetched = obsxa.observation.get(obs.id);
+    const fetched = await obsxa.observation.get(obs.id);
     expect(fetched?.context).toBe(obs.context);
   });
 
-  it("tracks edit history on updates", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const obs = obsxa.observation.add({
+  it("tracks edit history on updates", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const obs = await obsxa.observation.add({
       projectId: "p1",
       title: "A",
       source: "E1",
       confidence: 50,
     });
 
-    obsxa.observation.update(obs.id, { title: "A+", confidence: 88 });
-    obsxa.observation.update(obs.id, { confidence: 95, context: '{"env":"prod"}' });
+    await obsxa.observation.update(obs.id, { title: "A+", confidence: 88 });
+    await obsxa.observation.update(obs.id, { confidence: 95, context: '{"env":"prod"}' });
 
-    const edits = obsxa.observation.edits(obs.id);
+    const edits = await obsxa.observation.edits(obs.id);
     expect(edits.length).toBeGreaterThanOrEqual(3);
 
     const titleEdit = edits.find((e) => e.field === "title");
@@ -365,16 +409,16 @@ describe("obsxa", () => {
     expect(contextEdit!.newValue).toBe('{"env":"prod"}');
   });
 
-  it("dedup detects near-text duplicates via trigram similarity", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({
+  it("dedup detects near-text duplicates via trigram similarity", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({
       projectId: "p1",
       title: "Temperature spike detected at station seven",
       description: "Unusual reading above threshold",
       source: "sensor-a",
       tags: ["temperature"],
     });
-    obsxa.observation.add({
+    await obsxa.observation.add({
       projectId: "p1",
       title: "Temperature spike detected at station 7",
       description: "Unusual reading above the threshold",
@@ -382,43 +426,43 @@ describe("obsxa", () => {
       tags: ["temperature"],
     });
 
-    const scan = obsxa.dedup.scan("p1", 0.5);
+    const scan = await obsxa.dedup.scan("p1", 0.5);
     expect(scan.candidates.length).toBe(1);
     expect(scan.candidates[0]?.reason).toBe("near_text");
     expect(scan.candidates[0]?.score).toBeGreaterThan(0.5);
   });
 
-  it("dedup detects exact sourceRef matches", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({
+  it("dedup detects exact sourceRef matches", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({
       projectId: "p1",
       title: "Event from pipeline A",
       source: "pipeline-a",
       sourceRef: "evt:12345",
     });
-    obsxa.observation.add({
+    await obsxa.observation.add({
       projectId: "p1",
       title: "Same event from pipeline B",
       source: "pipeline-b",
       sourceRef: "evt:12345",
     });
 
-    const scan = obsxa.dedup.scan("p1");
+    const scan = await obsxa.dedup.scan("p1");
     expect(scan.candidates.length).toBe(1);
     expect(scan.candidates[0]?.reason).toBe("exact_source_ref");
     expect(scan.candidates[0]?.score).toBe(1);
   });
 
-  it("imports and batch-updates observations", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    const imported = obsxa.observation.addMany([
+  it("imports and batch-updates observations", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    const imported = await obsxa.observation.addMany([
       { projectId: "p1", title: "Imported A", source: "I1", evidenceStrength: 80 },
       { projectId: "p1", title: "Imported B", source: "I2", status: "dismissed" },
     ]);
     expect(imported).toHaveLength(2);
     expect(imported[1]?.status).toBe("dismissed");
 
-    const updated = obsxa.observation.updateMany([
+    const updated = await obsxa.observation.updateMany([
       { id: imported[0]!.id, novelty: 91, uncertainty: 12 },
       { id: imported[1]!.id, title: "Imported B2" },
     ]);
@@ -426,58 +470,36 @@ describe("obsxa", () => {
     expect(updated[1]?.title).toBe("Imported B2");
   });
 
-  it("creates backup before migration when schema is older", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({ projectId: "p1", title: "Persisted", source: "E1" });
-    obsxa.close();
+  it("creates backup before migration when schema is older", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({ projectId: "p1", title: "Persisted", source: "E1" });
+    await obsxa.close();
     obsxaClosed = true;
 
-    const sqlite = new Database(dbPath);
-    sqlite
-      .prepare(`
-      INSERT INTO obsxa_meta (key, value, updated_at)
-      VALUES (?, ?, strftime('%s', 'now'))
-      ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
-    `)
-      .run("schema_version", "1");
-    sqlite.close();
+    await setSchemaVersion(dbPath, 0);
 
-    const reopened = createObsxa({ db: dbPath, backupDir: dbDir });
-    const rows = reopened.observation.list("p1");
+    const reopened = await createObsxa({ db: dbPath, backupDir: dbDir });
+    const rows = await reopened.observation.list("p1");
     expect(rows).toHaveLength(1);
-    reopened.close();
+    await reopened.close();
 
     const backupFiles = readdirSync(dbDir).filter((name) => name.startsWith("test.db.bak."));
     expect(backupFiles.length).toBeGreaterThan(0);
   });
 
-  it("fails fast when database schema is newer than runtime", () => {
-    obsxa.close();
+  it("fails fast when database schema is newer than runtime", async () => {
+    await obsxa.close();
     obsxaClosed = true;
-    const sqlite = new Database(dbPath);
-    sqlite.exec(`
-      CREATE TABLE IF NOT EXISTS obsxa_meta (
-        key TEXT PRIMARY KEY NOT NULL,
-        value TEXT NOT NULL,
-        updated_at INTEGER NOT NULL
-      )
-    `);
-    sqlite
-      .prepare(`
-      INSERT INTO obsxa_meta (key, value, updated_at)
-      VALUES (?, ?, strftime('%s', 'now'))
-      ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
-    `)
-      .run("schema_version", "999");
-    sqlite.close();
 
-    expect(() => createObsxa({ db: dbPath })).toThrow(/newer than supported/);
+    await setSchemaVersion(dbPath, 999);
+
+    await expect(createObsxa({ db: dbPath })).rejects.toThrow(/newer than supported/);
   });
 
-  it("backs up and restores database files", () => {
-    obsxa.project.add({ id: "p1", name: "Obs Project" });
-    obsxa.observation.add({ projectId: "p1", title: "Before backup", source: "E1" });
-    obsxa.close();
+  it("backs up and restores database files", async () => {
+    await obsxa.project.add({ id: "p1", name: "Obs Project" });
+    await obsxa.observation.add({ projectId: "p1", title: "Before backup", source: "E1" });
+    await obsxa.close();
     obsxaClosed = true;
 
     const backupBase = join(dbDir, "manual-backup.db");
@@ -489,9 +511,9 @@ describe("obsxa", () => {
     expect(restored.files.length).toBeGreaterThan(0);
     expect(restored.preRestoreBackup).not.toBeNull();
 
-    const reopened = createObsxa({ db: dbPath });
-    const rows = reopened.observation.list("p1");
+    const reopened = await createObsxa({ db: dbPath });
+    const rows = await reopened.observation.list("p1");
     expect(rows).toHaveLength(1);
-    reopened.close();
+    await reopened.close();
   });
 });

--- a/test/usgs-earthquake.test.ts
+++ b/test/usgs-earthquake.test.ts
@@ -252,21 +252,21 @@ describe("usgs earthquake integration", () => {
   let dbPath: string;
   let obsxa: ObsxaInstance;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbDir = mkdtempSync(join(tmpdir(), "obsxa-usgs-"));
     dbPath = join(dbDir, "seismic.db");
-    obsxa = createObsxa({ db: dbPath });
+    obsxa = await createObsxa({ db: dbPath });
   });
 
-  afterEach(() => {
-    obsxa.close();
+  afterEach(async () => {
+    await obsxa.close();
     rmSync(dbDir, { recursive: true, force: true });
   });
 
-  it("ingests 14 earthquakes as observations", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("ingests 14 earthquakes as observations", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    const observations = obsxa.observation.addMany(
+    const observations = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -307,10 +307,10 @@ describe("usgs earthquake integration", () => {
     expect(observations.every((o) => o.capturedAt instanceof Date)).toBe(true);
   });
 
-  it("creates regional clusters and adds members", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("creates regional clusters and adds members", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    const added = obsxa.observation.addMany(
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -322,7 +322,6 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Build region → observation ids map
     const regionObs = new Map<string, number[]>();
     for (let i = 0; i < EARTHQUAKES.length; i++) {
       const region = regionKey(EARTHQUAKES[i]!.place);
@@ -331,25 +330,24 @@ describe("usgs earthquake integration", () => {
       regionObs.set(region, ids);
     }
 
-    // Create clusters only for regions with 2+ quakes
     const clustered = [...regionObs.entries()].filter(([, ids]) => ids.length >= 2);
-    expect(clustered.length).toBe(4); // japan, alaska, kamchatka, indonesia
+    expect(clustered.length).toBe(4);
 
     for (const [region, ids] of clustered) {
-      const cluster = obsxa.cluster.add({ projectId: "seismic", name: `Region: ${region}` });
+      const cluster = await obsxa.cluster.add({ projectId: "seismic", name: `Region: ${region}` });
       for (const id of ids) {
-        obsxa.cluster.addMember(cluster.id, id);
+        await obsxa.cluster.addMember(cluster.id, id);
       }
-      expect(obsxa.cluster.listMembers(cluster.id)).toHaveLength(ids.length);
+      expect(await obsxa.cluster.listMembers(cluster.id)).toHaveLength(ids.length);
     }
 
-    expect(obsxa.cluster.list("seismic")).toHaveLength(4);
+    expect(await obsxa.cluster.list("seismic")).toHaveLength(4);
   });
 
-  it("creates relations between earthquakes in same region", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("creates relations between earthquakes in same region", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    const added = obsxa.observation.addMany(
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -361,16 +359,15 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Japan cluster: 3 quakes near Hirara — same_signal_as
     const japan = added.slice(0, 3);
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: japan[1]!.id,
       toObservationId: japan[0]!.id,
       type: "same_signal_as",
       confidence: 90,
       notes: "Aftershock sequence near Hirara",
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: japan[2]!.id,
       toObservationId: japan[0]!.id,
       type: "same_signal_as",
@@ -378,39 +375,37 @@ describe("usgs earthquake integration", () => {
       notes: "Same fault system",
     });
 
-    // Alaska cluster: 3 quakes near Attu — supports
     const alaska = added.slice(3, 6);
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: alaska[1]!.id,
       toObservationId: alaska[0]!.id,
       type: "supports",
       confidence: 80,
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: alaska[2]!.id,
       toObservationId: alaska[0]!.id,
       type: "supports",
       confidence: 75,
     });
 
-    // Italy M6.0 contradicts the Chile deep quake (different mechanism)
-    const italy = added[11]!; // M6.0 shallow
-    const chile = added[13]!; // M5.1 deep
-    obsxa.relation.add({
+    const italy = added[11]!;
+    const chile = added[13]!;
+    await obsxa.relation.add({
       fromObservationId: italy.id,
       toObservationId: chile.id,
       type: "contradicts",
       notes: "Shallow crustal vs deep subduction",
     });
 
-    const japanRels = obsxa.relation.list(japan[0]!.id);
+    const japanRels = await obsxa.relation.list(japan[0]!.id);
     expect(japanRels).toHaveLength(2);
     expect(japanRels.every((r) => r.type === "same_signal_as")).toBe(true);
   });
 
-  it("analysis: stats reflect ingested data", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    obsxa.observation.addMany(
+  it("analysis: stats reflect ingested data", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -421,7 +416,7 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    const stats = obsxa.analysis.stats("seismic");
+    const stats = await obsxa.analysis.stats("seismic");
     expect(stats.total).toBe(14);
     expect(stats.active).toBe(14);
     expect(stats.promoted).toBe(0);
@@ -431,10 +426,10 @@ describe("usgs earthquake integration", () => {
     expect(stats.avgConfidence).toBeLessThanOrEqual(100);
   });
 
-  it("analysis: convergent detects multi-source support", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("analysis: convergent detects multi-source support", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    const added = obsxa.observation.addMany(
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -445,26 +440,25 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Alaska[0] supported by two different sources
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[4]!.id,
       toObservationId: added[3]!.id,
       type: "supports",
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[5]!.id,
       toObservationId: added[3]!.id,
       type: "supports",
     });
 
-    const convergent = obsxa.analysis.convergent("seismic");
+    const convergent = await obsxa.analysis.convergent("seismic");
     expect(convergent.map((o) => o.id)).toContain(added[3]!.id);
   });
 
-  it("analysis: isolated finds standalone quakes", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("analysis: isolated finds standalone quakes", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    const added = obsxa.observation.addMany(
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -475,30 +469,27 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Link Japan cluster only
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[1]!.id,
       toObservationId: added[0]!.id,
       type: "same_signal_as",
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[2]!.id,
       toObservationId: added[0]!.id,
       type: "same_signal_as",
     });
 
-    const isolated = obsxa.analysis.isolated("seismic");
-    // 14 total minus 3 linked = 11 isolated
+    const isolated = await obsxa.analysis.isolated("seismic");
     expect(isolated).toHaveLength(11);
-    // Japan quakes should NOT be isolated
     expect(isolated.map((o) => o.id)).not.toContain(added[0]!.id);
     expect(isolated.map((o) => o.id)).not.toContain(added[1]!.id);
     expect(isolated.map((o) => o.id)).not.toContain(added[2]!.id);
   });
 
-  it("analysis: triage ranks high-magnitude quakes first", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    obsxa.observation.addMany(
+  it("analysis: triage ranks high-magnitude quakes first", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -512,7 +503,7 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    const triaged = obsxa.analysis.triage("seismic", 5, "triage");
+    const triaged = await obsxa.analysis.triage("seismic", 5, "triage");
     expect(triaged).toHaveLength(5);
     const topTitles = triaged.slice(0, 2).map((t) => t.observation.title);
     expect(topTitles.some((t) => t.startsWith("M 6"))).toBe(true);
@@ -521,9 +512,9 @@ describe("usgs earthquake integration", () => {
     }
   });
 
-  it("analysis: frequent detects bumped quakes", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    const added = obsxa.observation.addMany(
+  it("analysis: frequent detects bumped quakes", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.slice(0, 3).map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -533,19 +524,18 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Aftershock recurrence — bump the main quake
-    obsxa.observation.incrementFrequency(added[0]!.id);
-    obsxa.observation.incrementFrequency(added[0]!.id);
+    await obsxa.observation.incrementFrequency(added[0]!.id);
+    await obsxa.observation.incrementFrequency(added[0]!.id);
 
-    const frequent = obsxa.analysis.frequent("seismic");
+    const frequent = await obsxa.analysis.frequent("seismic");
     expect(frequent).toHaveLength(1);
     expect(frequent[0]!.id).toBe(added[0]!.id);
     expect(frequent[0]!.frequency).toBe(3);
   });
 
-  it("search finds earthquakes by region and magnitude", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    obsxa.observation.addMany(
+  it("search finds earthquakes by region and magnitude", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -557,19 +547,19 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    const japanResults = obsxa.search.search("Japan", "seismic");
+    const japanResults = await obsxa.search.search("Japan", "seismic");
     expect(japanResults.length).toBe(3);
 
-    const italyResults = obsxa.search.search("Italy", "seismic");
+    const italyResults = await obsxa.search.search("Italy", "seismic");
     expect(italyResults.length).toBe(1);
 
-    const alaskaResults = obsxa.search.search("Alaska", "seismic");
+    const alaskaResults = await obsxa.search.search("Alaska", "seismic");
     expect(alaskaResults.length).toBe(3);
   });
 
-  it("lifecycle: dismiss, archive, promote", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    const added = obsxa.observation.addMany(
+  it("lifecycle: dismiss, archive, promote", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.slice(0, 4).map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -579,49 +569,42 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Dismiss a low-significance quake
-    const dismissed = obsxa.observation.dismiss(added[2]!.id, {
+    const dismissed = await obsxa.observation.dismiss(added[2]!.id, {
       reasonCode: "noise",
       reasonNote: "Below signal threshold",
     });
     expect(dismissed.status).toBe("dismissed");
 
-    // Archive for later reference
-    const archived = obsxa.observation.archive(added[3]!.id, {
+    const archived = await obsxa.observation.archive(added[3]!.id, {
       reasonCode: "manual_review",
       reasonNote: "Needs geological review",
     });
     expect(archived.status).toBe("archived");
 
-    // Promote the main Japan quake to hypothesis
-    const promoted = obsxa.observation.promote(added[0]!.id, "hypxa:seismic:hirara-swarm");
+    const promoted = await obsxa.observation.promote(added[0]!.id, "hypxa:seismic:hirara-swarm");
     expect(promoted.status).toBe("promoted");
     expect(promoted.promotedTo).toBe("hypxa:seismic:hirara-swarm");
 
-    // Check transitions recorded
-    const transitions = obsxa.observation.transitions(added[0]!.id);
+    const transitions = await obsxa.observation.transitions(added[0]!.id);
     expect(transitions).toHaveLength(1);
     expect(transitions[0]!.toStatus).toBe("promoted");
 
-    // Stats reflect lifecycle changes
-    const stats = obsxa.analysis.stats("seismic");
-    expect(stats.active).toBe(1); // only added[1] remains active
+    const stats = await obsxa.analysis.stats("seismic");
+    expect(stats.active).toBe(1);
     expect(stats.promoted).toBe(1);
     expect(stats.dismissed).toBe(1);
     expect(stats.archived).toBe(1);
 
-    // Unpromoted should only contain the active one
-    const unpromoted = obsxa.analysis.unpromoted("seismic");
+    const unpromoted = await obsxa.analysis.unpromoted("seismic");
     expect(unpromoted).toHaveLength(1);
     expect(unpromoted[0]!.id).toBe(added[1]!.id);
   });
 
-  it("dedup: detects near-identical observations", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+  it("dedup: detects near-identical observations", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
 
-    // Simulate duplicate ingestion (same earthquake from two pipeline runs)
     const quake = EARTHQUAKES[0]!;
-    obsxa.observation.add({
+    await obsxa.observation.add({
       projectId: "seismic",
       title: `M ${quake.mag} - ${quake.place}`,
       description: `Magnitude ${quake.mag} at depth ${quake.depth} km`,
@@ -630,7 +613,7 @@ describe("usgs earthquake integration", () => {
       sourceType: "external",
       tags: ["japan"],
     });
-    obsxa.observation.add({
+    await obsxa.observation.add({
       projectId: "seismic",
       title: `M ${quake.mag} - ${quake.place}`,
       description: `Magnitude ${quake.mag} at depth ${quake.depth} km`,
@@ -640,13 +623,12 @@ describe("usgs earthquake integration", () => {
       tags: ["japan"],
     });
 
-    const scan = obsxa.dedup.scan("seismic");
+    const scan = await obsxa.dedup.scan("seismic");
     expect(scan.checkedPairs).toBe(1);
     expect(scan.candidates).toHaveLength(1);
     expect(scan.candidates[0]!.reason).toBe("exact_fingerprint");
 
-    // Merge the duplicate
-    const merged = obsxa.dedup.merge(
+    const merged = await obsxa.dedup.merge(
       scan.candidates[0]!.primaryObservationId,
       scan.candidates[0]!.duplicateObservationId,
       { confidenceStrategy: "max", relationType: "duplicate_of" },
@@ -654,13 +636,13 @@ describe("usgs earthquake integration", () => {
     expect(merged.primary.frequency).toBe(2);
     expect(merged.merged.status).toBe("archived");
 
-    const resolved = obsxa.dedup.candidates("seismic", "resolved");
+    const resolved = await obsxa.dedup.candidates("seismic", "resolved");
     expect(resolved).toHaveLength(1);
   });
 
-  it("export/import round-trip preserves data", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    const originals = obsxa.observation.addMany(
+  it("export/import round-trip preserves data", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    const originals = await obsxa.observation.addMany(
       EARTHQUAKES.slice(0, 5).map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -674,13 +656,11 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    // Export as list
-    const exported = obsxa.observation.list("seismic");
+    const exported = await obsxa.observation.list("seismic");
     expect(exported).toHaveLength(5);
 
-    // Re-import into a fresh project
-    obsxa.project.add({ id: "seismic-copy", name: "Copy" });
-    const reimported = obsxa.observation.addMany(
+    await obsxa.project.add({ id: "seismic-copy", name: "Copy" });
+    const reimported = await obsxa.observation.addMany(
       exported.map((o) => ({
         projectId: "seismic-copy",
         title: o.title,
@@ -696,17 +676,19 @@ describe("usgs earthquake integration", () => {
     );
 
     expect(reimported).toHaveLength(5);
+    const originalsByTitle = [...originals].sort((a, b) => a.title.localeCompare(b.title));
+    const reimportedByTitle = [...reimported].sort((a, b) => a.title.localeCompare(b.title));
     for (let i = 0; i < 5; i++) {
-      expect(reimported[i]!.title).toBe(originals[i]!.title);
-      expect(reimported[i]!.confidence).toBe(originals[i]!.confidence);
-      expect(reimported[i]!.type).toBe(originals[i]!.type);
-      expect(reimported[i]!.tags).toEqual(originals[i]!.tags);
+      expect(reimportedByTitle[i]!.title).toBe(originalsByTitle[i]!.title);
+      expect(reimportedByTitle[i]!.confidence).toBe(originalsByTitle[i]!.confidence);
+      expect(reimportedByTitle[i]!.type).toBe(originalsByTitle[i]!.type);
+      expect(reimportedByTitle[i]!.tags).toEqual(originalsByTitle[i]!.tags);
     }
   });
 
-  it("TOON encode/decode round-trip", () => {
-    obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
-    obsxa.observation.addMany(
+  it("TOON encode/decode round-trip", async () => {
+    await obsxa.project.add({ id: "seismic", name: "USGS Seismic Monitor" });
+    await obsxa.observation.addMany(
       EARTHQUAKES.slice(0, 3).map((eq) => ({
         projectId: "seismic",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -718,31 +700,30 @@ describe("usgs earthquake integration", () => {
       })),
     );
 
-    const observations = obsxa.observation.list("seismic");
+    const observations = await obsxa.observation.list("seismic");
     const toonStr = encode(observations);
     expect(typeof toonStr).toBe("string");
     expect(toonStr.length).toBeGreaterThan(0);
 
     const decoded = decode(toonStr) as unknown as Observation[];
     expect(decoded).toHaveLength(3);
-    // TOON preserves structure — titles match
+    const decodedByTitle = [...decoded].sort((a, b) => a.title.localeCompare(b.title));
+    const observationsByTitle = [...observations].sort((a, b) => a.title.localeCompare(b.title));
     for (let i = 0; i < 3; i++) {
-      expect(decoded[i]!.title).toBe(observations[i]!.title);
-      expect(decoded[i]!.confidence).toBe(observations[i]!.confidence);
+      expect(decodedByTitle[i]!.title).toBe(observationsByTitle[i]!.title);
+      expect(decodedByTitle[i]!.confidence).toBe(observationsByTitle[i]!.confidence);
     }
   });
 
-  it("end-to-end: full pipeline from ingest to triage", () => {
-    // 1. Create project
-    const project = obsxa.project.add({
+  it("end-to-end: full pipeline from ingest to triage", async () => {
+    const project = await obsxa.project.add({
       id: "seismic-e2e",
       name: "E2E Seismic Monitor",
       description: "Full pipeline test with USGS data",
     });
     expect(project.id).toBe("seismic-e2e");
 
-    // 2. Ingest all 14 earthquakes
-    const added = obsxa.observation.addMany(
+    const added = await obsxa.observation.addMany(
       EARTHQUAKES.map((eq) => ({
         projectId: "seismic-e2e",
         title: `M ${eq.mag} - ${eq.place}`,
@@ -764,49 +745,43 @@ describe("usgs earthquake integration", () => {
     );
     expect(added).toHaveLength(14);
 
-    // 3. Create relations (within-region)
-    // Japan aftershock sequence
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[1]!.id,
       toObservationId: added[0]!.id,
       type: "same_signal_as",
       confidence: 90,
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[2]!.id,
       toObservationId: added[0]!.id,
       type: "same_signal_as",
       confidence: 85,
     });
-    // Alaska seismicity
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[4]!.id,
       toObservationId: added[3]!.id,
       type: "supports",
       confidence: 80,
     });
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[5]!.id,
       toObservationId: added[3]!.id,
       type: "supports",
       confidence: 75,
     });
-    // Kamchatka pair
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[7]!.id,
       toObservationId: added[6]!.id,
       type: "supports",
       confidence: 82,
     });
-    // Indonesia pair
-    obsxa.relation.add({
+    await obsxa.relation.add({
       fromObservationId: added[9]!.id,
       toObservationId: added[8]!.id,
       type: "supports",
       confidence: 78,
     });
 
-    // 4. Create regional clusters
     const regions: Record<string, number[]> = {};
     for (let i = 0; i < EARTHQUAKES.length; i++) {
       const r = regionKey(EARTHQUAKES[i]!.place);
@@ -816,75 +791,63 @@ describe("usgs earthquake integration", () => {
     let clusterCount = 0;
     for (const [region, ids] of Object.entries(regions)) {
       if (ids.length >= 2) {
-        const c = obsxa.cluster.add({ projectId: "seismic-e2e", name: `Region: ${region}` });
-        for (const id of ids) obsxa.cluster.addMember(c.id, id);
+        const c = await obsxa.cluster.add({ projectId: "seismic-e2e", name: `Region: ${region}` });
+        for (const id of ids) await obsxa.cluster.addMember(c.id, id);
         clusterCount++;
       }
     }
     expect(clusterCount).toBe(4);
 
-    // 5. Bump frequency on notable Japan swarm
-    obsxa.observation.incrementFrequency(added[0]!.id);
+    await obsxa.observation.incrementFrequency(added[0]!.id);
 
-    // 6. Analysis
-    const stats = obsxa.analysis.stats("seismic-e2e");
+    const stats = await obsxa.analysis.stats("seismic-e2e");
     expect(stats.total).toBe(14);
     expect(stats.active).toBe(14);
     expect(stats.totalClusters).toBe(4);
     expect(stats.byType.measurement).toBe(14);
 
-    const frequent = obsxa.analysis.frequent("seismic-e2e");
+    const frequent = await obsxa.analysis.frequent("seismic-e2e");
     expect(frequent).toHaveLength(1);
     expect(frequent[0]!.id).toBe(added[0]!.id);
 
-    const convergent = obsxa.analysis.convergent("seismic-e2e");
-    // Alaska[0] has 2 supports from different sources
+    const convergent = await obsxa.analysis.convergent("seismic-e2e");
     expect(convergent.map((o) => o.id)).toContain(added[3]!.id);
 
-    const isolated = obsxa.analysis.isolated("seismic-e2e");
-    // Tonga, Philippines, Chile are standalone (no relations)
-    expect(isolated.map((o) => o.id)).toContain(added[10]!.id); // Tonga
-    expect(isolated.map((o) => o.id)).toContain(added[12]!.id); // Philippines
-    expect(isolated.map((o) => o.id)).toContain(added[13]!.id); // Chile
+    const isolated = await obsxa.analysis.isolated("seismic-e2e");
+    expect(isolated.map((o) => o.id)).toContain(added[10]!.id);
+    expect(isolated.map((o) => o.id)).toContain(added[12]!.id);
+    expect(isolated.map((o) => o.id)).toContain(added[13]!.id);
 
-    const triaged = obsxa.analysis.triage("seismic-e2e", 14, "triage");
+    const triaged = await obsxa.analysis.triage("seismic-e2e", 14, "triage");
     expect(triaged).toHaveLength(14);
-    // Top score should be high
     expect(triaged[0]!.score).toBeGreaterThan(0);
 
-    // 7. Lifecycle operations
-    // Promote the Japan swarm leader as hypothesis
-    obsxa.observation.promote(added[0]!.id, "hypxa:seismic:hirara-swarm-2026");
-    // Dismiss Tonga as isolated low-interest
-    obsxa.observation.dismiss(added[10]!.id, {
+    await obsxa.observation.promote(added[0]!.id, "hypxa:seismic:hirara-swarm-2026");
+    await obsxa.observation.dismiss(added[10]!.id, {
       reasonCode: "noise",
       reasonNote: "Isolated deep event",
     });
-    // Archive Chile deep quake
-    obsxa.observation.archive(added[13]!.id, { reasonCode: "manual_review" });
+    await obsxa.observation.archive(added[13]!.id, { reasonCode: "manual_review" });
 
-    const finalStats = obsxa.analysis.stats("seismic-e2e");
+    const finalStats = await obsxa.analysis.stats("seismic-e2e");
     expect(finalStats.promoted).toBe(1);
     expect(finalStats.dismissed).toBe(1);
     expect(finalStats.archived).toBe(1);
     expect(finalStats.active).toBe(11);
 
-    // 8. Search
-    const searchJapan = obsxa.search.search("Hirara", "seismic-e2e");
+    const searchJapan = await obsxa.search.search("Hirara", "seismic-e2e");
     expect(searchJapan.length).toBe(3);
 
-    const searchItaly = obsxa.search.search("Anacapri", "seismic-e2e");
+    const searchItaly = await obsxa.search.search("Anacapri", "seismic-e2e");
     expect(searchItaly.length).toBe(1);
 
-    // 9. Unpromoted — should not contain promoted/dismissed/archived
-    const unpromoted = obsxa.analysis.unpromoted("seismic-e2e");
-    expect(unpromoted.map((o) => o.id)).not.toContain(added[0]!.id); // promoted
-    expect(unpromoted.map((o) => o.id)).not.toContain(added[10]!.id); // dismissed
-    expect(unpromoted.map((o) => o.id)).not.toContain(added[13]!.id); // archived
+    const unpromoted = await obsxa.analysis.unpromoted("seismic-e2e");
+    expect(unpromoted.map((o) => o.id)).not.toContain(added[0]!.id);
+    expect(unpromoted.map((o) => o.id)).not.toContain(added[10]!.id);
+    expect(unpromoted.map((o) => o.id)).not.toContain(added[13]!.id);
     expect(unpromoted).toHaveLength(11);
 
-    // 10. TOON round-trip on final state
-    const allObs = obsxa.observation.list("seismic-e2e");
+    const allObs = await obsxa.observation.list("seismic-e2e");
     const toonStr = encode(allObs);
     const decoded = decode(toonStr) as unknown as Observation[];
     expect(decoded).toHaveLength(14);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "types": ["node"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "moduleDetection": "force",


### PR DESCRIPTION
## What
Migrates obsxa from better-sqlite3 to @libsql/client and converts the data path to async end-to-end, including createObsxa, core stores, CLI commands, AI tools, and docs/tests, so runtime behavior stays the same while using Drizzle libsql APIs.

## Closes
Closes #10