### PR TITLE
fix(cli): validate observation percentage inputs

### DIFF
--- a/src/commands/observation.ts
+++ b/src/commands/observation.ts
@@ -48,7 +48,7 @@ export function parseOptionalInt(
     consola.error(`--${name} must not be empty`);
     process.exit(1);
   }
-  if (!/^\d+$/.test(value)) {
+  if (!/^-?\d+$/.test(value)) {
     consola.error(`--${name} must be an integer, got "${value}"`);
     process.exit(1);
   }
@@ -69,6 +69,27 @@ export function parseOptionalInt(
 }
 
 const percentRange = { min: 0, max: 100 };
+const recordPercentFields = ["confidence", "evidenceStrength", "novelty", "uncertainty"] as const;
+
+type RecordPercentField = (typeof recordPercentFields)[number];
+
+export function validateRecordPercentages(
+  record: Partial<Record<RecordPercentField, unknown>>,
+  index: number,
+) {
+  for (const field of recordPercentFields) {
+    const value = record[field];
+    if (value === undefined) continue;
+    if (typeof value !== "number" || !Number.isFinite(value) || !Number.isSafeInteger(value)) {
+      consola.error(`Record[${index}].${field} must be an integer between 0 and 100`);
+      process.exit(1);
+    }
+    if (value < percentRange.min || value > percentRange.max) {
+      consola.error(`Record[${index}].${field} must be between 0 and 100`);
+      process.exit(1);
+    }
+  }
+}
 
 function readDataFile<T>(filePath: string): T {
   try {
@@ -179,6 +200,9 @@ export default defineCommand({
               consola.error("Import file must contain a JSON array");
               process.exit(1);
             }
+            records.forEach((record, index) => {
+              validateRecordPercentages(record, index);
+            });
             const obsxa = await open(args.db);
             try {
               const imported = await obsxa.observation.addMany(records);
@@ -247,6 +271,9 @@ export default defineCommand({
               consola.error("Batch-update file must contain a JSON array");
               process.exit(1);
             }
+            records.forEach((record, index) => {
+              validateRecordPercentages(record, index);
+            });
             const obsxa = await open(args.db);
             try {
               const updated = await obsxa.observation.updateMany(records);

--- a/src/commands/observation.ts
+++ b/src/commands/observation.ts
@@ -38,14 +38,37 @@ function parseTags(tags?: string): string[] | undefined {
     .filter(Boolean);
 }
 
-function parseOptionalInt(value?: string, name = "value"): number | undefined {
-  if (!value) return undefined;
+export function parseOptionalInt(
+  value?: string,
+  name = "value",
+  opts?: { min?: number; max?: number },
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (value.length === 0) {
+    consola.error(`--${name} must not be empty`);
+    process.exit(1);
+  }
   if (!/^\d+$/.test(value)) {
     consola.error(`--${name} must be an integer, got "${value}"`);
     process.exit(1);
   }
-  return Number(value);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    consola.error(`--${name} must be a safe integer, got "${value}"`);
+    process.exit(1);
+  }
+  if (opts?.min !== undefined && parsed < opts.min) {
+    consola.error(`--${name} must be at least ${opts.min}, got "${value}"`);
+    process.exit(1);
+  }
+  if (opts?.max !== undefined && parsed > opts.max) {
+    consola.error(`--${name} must be at most ${opts.max}, got "${value}"`);
+    process.exit(1);
+  }
+  return parsed;
 }
+
+const percentRange = { min: 0, max: 100 };
 
 function readDataFile<T>(filePath: string): T {
   try {
@@ -116,7 +139,7 @@ export default defineCommand({
                 type: args.type as ObservationType | undefined,
                 source: args.source,
                 sourceType: args["source-type"] as SourceType | undefined,
-                confidence: parseOptionalInt(args.confidence, "confidence"),
+                confidence: parseOptionalInt(args.confidence, "confidence", percentRange),
                 tags: parseTags(args.tags),
                 data: args.data,
                 context: args.context,
@@ -124,9 +147,9 @@ export default defineCommand({
                 sourceRef: args["source-ref"],
                 collector: args.collector,
                 inputHash: args["input-hash"],
-                evidenceStrength: parseOptionalInt(args.evidence, "evidence"),
-                novelty: parseOptionalInt(args.novelty, "novelty"),
-                uncertainty: parseOptionalInt(args.uncertainty, "uncertainty"),
+                evidenceStrength: parseOptionalInt(args.evidence, "evidence", percentRange),
+                novelty: parseOptionalInt(args.novelty, "novelty", percentRange),
+                uncertainty: parseOptionalInt(args.uncertainty, "uncertainty", percentRange),
                 reproducibilityHint: args.reproducibility,
               });
               if (args.toon || args.json) return output(observation, args.toon);
@@ -369,7 +392,7 @@ export default defineCommand({
             type: { type: "string", description: "Type" },
             source: { type: "string", description: "Source" },
             "source-type": { type: "string", description: "Source type" },
-            confidence: { type: "string", description: "Confidence" },
+            confidence: { type: "string", description: "Confidence 0-100" },
             tags: { type: "string", description: "Comma-separated tags" },
             data: { type: "string", description: "Data payload" },
             context: { type: "string", description: "Observation conditions/environment (JSON)" },
@@ -377,9 +400,9 @@ export default defineCommand({
             "source-ref": { type: "string", description: "Source reference" },
             collector: { type: "string", description: "Collector identity" },
             "input-hash": { type: "string", description: "Input hash" },
-            evidence: { type: "string", description: "Evidence strength" },
-            novelty: { type: "string", description: "Novelty" },
-            uncertainty: { type: "string", description: "Uncertainty" },
+            evidence: { type: "string", description: "Evidence strength 0-100" },
+            novelty: { type: "string", description: "Novelty 0-100" },
+            uncertainty: { type: "string", description: "Uncertainty 0-100" },
             reproducibility: { type: "string", description: "Reproducibility hint" },
           },
           async run({ args }) {
@@ -404,7 +427,7 @@ export default defineCommand({
                 type: args.type as ObservationType | undefined,
                 source: args.source,
                 sourceType: args["source-type"] as SourceType | undefined,
-                confidence: parseOptionalInt(args.confidence, "confidence"),
+                confidence: parseOptionalInt(args.confidence, "confidence", percentRange),
                 tags: parseTags(args.tags),
                 data: args.data,
                 context: args.context,
@@ -412,9 +435,9 @@ export default defineCommand({
                 sourceRef: args["source-ref"],
                 collector: args.collector,
                 inputHash: args["input-hash"],
-                evidenceStrength: parseOptionalInt(args.evidence, "evidence"),
-                novelty: parseOptionalInt(args.novelty, "novelty"),
-                uncertainty: parseOptionalInt(args.uncertainty, "uncertainty"),
+                evidenceStrength: parseOptionalInt(args.evidence, "evidence", percentRange),
+                novelty: parseOptionalInt(args.novelty, "novelty", percentRange),
+                uncertainty: parseOptionalInt(args.uncertainty, "uncertainty", percentRange),
                 reproducibilityHint: args.reproducibility,
               });
               if (args.toon || args.json) return output(result, args.toon);

--- a/test/observation-parse.test.ts
+++ b/test/observation-parse.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { parseOptionalInt } from "../src/commands/observation.ts";
+import { parseOptionalInt, validateRecordPercentages } from "../src/commands/observation.ts";
 
-function withProcessExitStub(fn: () => void) {
+function withProcessExitStub(fn: () => void): void {
   const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
     throw new Error(`process.exit:${code ?? 0}`);
   });
@@ -34,6 +34,22 @@ describe("parseOptionalInt", () => {
     ).toThrow("process.exit:1");
   });
 
+  it("exits for negative values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        parseOptionalInt("-1", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+
+  it("exits for non-numeric values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        parseOptionalInt("abc", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+
   it("exits for empty string", () => {
     expect(() =>
       withProcessExitStub(() => {
@@ -46,6 +62,45 @@ describe("parseOptionalInt", () => {
     expect(() =>
       withProcessExitStub(() => {
         parseOptionalInt("9007199254740993", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+});
+
+describe("validateRecordPercentages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts integer percentages in range", () => {
+    expect(() => {
+      validateRecordPercentages(
+        { confidence: 10, evidenceStrength: 20, novelty: 30, uncertainty: 40 },
+        0,
+      );
+    }).not.toThrow();
+  });
+
+  it("exits for out-of-range record values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        validateRecordPercentages({ confidence: 101 }, 3);
+      }),
+    ).toThrow("process.exit:1");
+  });
+
+  it("exits for decimal record values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        validateRecordPercentages({ novelty: 12.5 }, 1);
+      }),
+    ).toThrow("process.exit:1");
+  });
+
+  it("exits for non-number record values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        validateRecordPercentages({ uncertainty: "15" }, 2);
       }),
     ).toThrow("process.exit:1");
   });

--- a/test/observation-parse.test.ts
+++ b/test/observation-parse.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseOptionalInt } from "../src/commands/observation.ts";
+
+function withProcessExitStub(fn: () => void) {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? 0}`);
+  });
+  try {
+    fn();
+  } finally {
+    exitSpy.mockRestore();
+  }
+}
+
+describe("parseOptionalInt", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined for missing value", () => {
+    expect(parseOptionalInt(undefined, "confidence", { min: 0, max: 100 })).toBeUndefined();
+  });
+
+  it("accepts values inside range", () => {
+    expect(parseOptionalInt("0", "confidence", { min: 0, max: 100 })).toBe(0);
+    expect(parseOptionalInt("100", "confidence", { min: 0, max: 100 })).toBe(100);
+  });
+
+  it("exits for out-of-range values", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        parseOptionalInt("101", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+
+  it("exits for empty string", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        parseOptionalInt("", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+
+  it("exits for unsafe integers", () => {
+    expect(() =>
+      withProcessExitStub(() => {
+        parseOptionalInt("9007199254740993", "confidence", { min: 0, max: 100 });
+      }),
+    ).toThrow("process.exit:1");
+  });
+});


### PR DESCRIPTION
Closes #4

I hit this while checking machine-output workflows: passing values like "--confidence 999" looked successful but silently stored clamped values. This patch makes the CLI reject invalid percentage inputs up front so scripts fail loudly instead of writing misleading data.

What changed:
- enforce 0-100 bounds for observation add and update percentage fields (confidence, evidence, novelty, uncertainty)
- reject explicit empty values and unsafe integers in the shared observation integer parser
- add focused tests for missing, valid, out-of-range, empty, and unsafe integer inputs

Validation run locally:
- pnpm test:run
- pnpm lint
- pnpm typecheck
- pnpm build
- cubic review (no issues)
- coderabbit review --plain --type uncommitted (no findings)
