### PR TITLE
fix(cli): add --toon parity to backup command

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
+import { dbArgs, output } from "./_db.ts";
 import { backupDatabase, restoreDatabase } from "../backup.ts";
 
 export default defineCommand({
@@ -10,17 +11,13 @@ export default defineCommand({
         defineCommand({
           meta: { name: "create", description: "Create database backup (db, wal, shm)" },
           args: {
-            db: { type: "string", default: "./obsxa.db", description: "Path to SQLite database" },
+            ...dbArgs,
             out: { type: "string", description: "Backup base path (without -wal/-shm suffixes)" },
-            json: { type: "boolean", default: false, description: "Output as JSON" },
           },
           run({ args }) {
             try {
               const result = backupDatabase(args.db, args.out);
-              if (args.json) {
-                process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-                return;
-              }
+              if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Backup created: ${result.basePath}`);
             } catch (err) {
               consola.error(`Backup failed: ${(err as Error).message}`);
@@ -35,25 +32,17 @@ export default defineCommand({
         defineCommand({
           meta: { name: "restore", description: "Restore database from backup base path" },
           args: {
-            db: {
-              type: "string",
-              default: "./obsxa.db",
-              description: "Target SQLite database path",
-            },
+            ...dbArgs,
             from: {
               type: "string",
               required: true,
               description: "Backup base path to restore from",
             },
-            json: { type: "boolean", default: false, description: "Output as JSON" },
           },
           run({ args }) {
             try {
               const result = restoreDatabase(args.db, args.from);
-              if (args.json) {
-                process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-                return;
-              }
+              if (args.toon || args.json) return output(result, args.toon);
               consola.success(`Database restored from: ${result.restoredFrom}`);
               if (result.preRestoreBackup) {
                 consola.info(`Pre-restore safety backup: ${result.preRestoreBackup}`);

--- a/test/backup-command.test.ts
+++ b/test/backup-command.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import backupCommand from "../src/commands/backup.ts";
+import { backupDatabase, restoreDatabase } from "../src/backup.ts";
+import { output } from "../src/commands/_db.ts";
+
+vi.mock("../src/backup.ts", () => ({
+  backupDatabase: vi.fn(),
+  restoreDatabase: vi.fn(),
+}));
+
+vi.mock("../src/commands/_db.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/commands/_db.ts")>();
+  return {
+    ...actual,
+    output: vi.fn(),
+  };
+});
+
+async function loadSubcommand(name: "create" | "restore") {
+  const factory = backupCommand.subCommands?.[name];
+  if (!factory) throw new Error(`Missing ${name} subcommand`);
+  return factory();
+}
+
+describe("backup command output parity", () => {
+  it("supports TOON output for backup create", async () => {
+    const result = { basePath: "/tmp/obsxa.db.bak", files: ["/tmp/obsxa.db.bak"] };
+    vi.mocked(backupDatabase).mockReturnValue(result);
+
+    const command = await loadSubcommand("create");
+    await command.run?.({
+      args: { db: "./obsxa.db", out: "/tmp/obsxa.db.bak", json: false, toon: true },
+    });
+
+    expect(output).toHaveBeenCalledWith(result, true);
+  });
+
+  it("supports TOON output for backup restore", async () => {
+    const result = {
+      restoredFrom: "/tmp/obsxa.db.bak",
+      target: "./obsxa.db",
+      files: ["./obsxa.db"],
+      preRestoreBackup: null,
+    };
+    vi.mocked(restoreDatabase).mockReturnValue(result);
+
+    const command = await loadSubcommand("restore");
+    await command.run?.({
+      args: { db: "./obsxa.db", from: "/tmp/obsxa.db.bak", json: false, toon: true },
+    });
+
+    expect(output).toHaveBeenCalledWith(result, true);
+  });
+});


### PR DESCRIPTION
Fixes #5

Backup was the only command path that could not emit TOON, which broke machine output consistency across the CLI. This change switches backup create and restore to shared command args and shared output handling, so json and toon output now work the same way as other commands.

Added test/backup-command.test.ts to lock this behavior for both subcommands.