### PR TITLE
chore(release): ship opencode wrapper flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,7 @@ jobs:
       - run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - run: pnpm publish --dir ./opencode --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🏡 Chore
+
+- **release:** Simplify release flow to one script and sync version for wrapper `opencode` package
+- **release:** Publish wrapper package from `opencode/` in release workflow
+
 ### ⚠️ Notes
 
 - **db path:** `createObsxa()` now defaults to an XDG-compliant data path (`~/.local/share/obsxa/obsxa.db` on Linux) instead of `./obsxa.db`. Pass `db: "./obsxa.db"` explicitly to keep legacy location.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **release:** Simplify release flow to one script and sync version for wrapper `opencode` package
 - **release:** Publish wrapper package from `opencode/` in release workflow
+- **release:** Keep single root changelog/release and sync wrapper package metadata only
 
 ### ⚠️ Notes
 

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## Unreleased

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-## Unreleased

--- a/opencode/index.d.mts
+++ b/opencode/index.d.mts
@@ -1,0 +1,1 @@
+export { createObsxaPlugin, createObsxaPlugin as default } from "obsxa/opencode";

--- a/opencode/index.mjs
+++ b/opencode/index.mjs
@@ -1,0 +1,2 @@
+export { createObsxaPlugin } from "obsxa/opencode";
+export { createObsxaPlugin as default } from "obsxa/opencode";

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "obsxa-opencode",
+  "version": "0.0.2",
+  "description": "OpenCode plugin wrapper package for obsxa",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oritwoen/obsxa.git"
+  },
+  "files": [
+    "index.mjs"
+  ],
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "dependencies": {
+    "obsxa": "0.0.2"
+  }
+}

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -8,12 +8,17 @@
     "url": "git+https://github.com/oritwoen/obsxa.git"
   },
   "files": [
-    "index.mjs"
+    "index.mjs",
+    "index.d.mts"
   ],
   "type": "module",
   "main": "./index.mjs",
+  "types": "./index.d.mts",
   "exports": {
-    ".": "./index.mjs"
+    ".": {
+      "types": "./index.d.mts",
+      "default": "./index.mjs"
+    }
   },
   "dependencies": {
     "obsxa": "0.0.2"

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -16,6 +16,6 @@
     ".": "./index.mjs"
   },
   "dependencies": {
-    "obsxa": "*"
+    "obsxa": "0.0.2"
   }
 }

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -16,6 +16,6 @@
     ".": "./index.mjs"
   },
   "dependencies": {
-    "obsxa": "0.0.2"
+    "obsxa": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:run": "vitest --run",
     "generate": "drizzle-kit generate",
     "prepack": "pnpm run build",
-    "release": "pnpm test:run && pnpm build && changelogen --release --push"
+    "release": "pnpm test:run && pnpm build && node ./scripts/release-with-opencode.mjs"
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",

--- a/scripts/release-with-opencode.mjs
+++ b/scripts/release-with-opencode.mjs
@@ -30,6 +30,8 @@ function syncOpencodePackageVersion(version) {
 
   const opencodePackageJson = JSON.parse(readFileSync(opencodePackageJsonPath, "utf8"));
   opencodePackageJson.version = version;
+  opencodePackageJson.dependencies ??= {};
+  opencodePackageJson.dependencies.obsxa = version;
   writeFileSync(
     opencodePackageJsonPath,
     `${JSON.stringify(opencodePackageJson, null, 2)}\n`,

--- a/scripts/release-with-opencode.mjs
+++ b/scripts/release-with-opencode.mjs
@@ -44,5 +44,4 @@ runChangelogen(["--bump"]);
 const version = readRootVersion();
 syncOpencodePackageVersion(version);
 
-runChangelogen(["--bump", "--dir", "./opencode", "-r", version]);
 runChangelogen(["--release", "-r", version, "--push"]);

--- a/scripts/release-with-opencode.mjs
+++ b/scripts/release-with-opencode.mjs
@@ -1,0 +1,44 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packageJsonPath = resolve(rootDir, "package.json");
+const opencodePackageJsonPath = resolve(rootDir, "opencode/package.json");
+
+function runChangelogen(args) {
+  execFileSync("changelogen", args, {
+    cwd: rootDir,
+    stdio: "inherit",
+  });
+}
+
+function readRootVersion() {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const version = packageJson.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error("Missing version in package.json");
+  }
+  return version;
+}
+
+function syncOpencodePackageVersion(version) {
+  const opencodePackageJson = JSON.parse(readFileSync(opencodePackageJsonPath, "utf8"));
+  opencodePackageJson.version = version;
+  opencodePackageJson.dependencies ??= {};
+  opencodePackageJson.dependencies.obsxa = version;
+  writeFileSync(
+    opencodePackageJsonPath,
+    `${JSON.stringify(opencodePackageJson, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+runChangelogen(["--bump"]);
+
+const version = readRootVersion();
+syncOpencodePackageVersion(version);
+
+runChangelogen(["--bump", "--dir", "./opencode", "-r", version]);
+runChangelogen(["--release", "-r", version, "--push"]);

--- a/scripts/release-with-opencode.mjs
+++ b/scripts/release-with-opencode.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -24,10 +24,12 @@ function readRootVersion() {
 }
 
 function syncOpencodePackageVersion(version) {
+  if (!existsSync(opencodePackageJsonPath)) {
+    throw new Error(`Missing wrapper package definition at ${opencodePackageJsonPath}`);
+  }
+
   const opencodePackageJson = JSON.parse(readFileSync(opencodePackageJsonPath, "utf8"));
   opencodePackageJson.version = version;
-  opencodePackageJson.dependencies ??= {};
-  opencodePackageJson.dependencies.obsxa = version;
   writeFileSync(
     opencodePackageJsonPath,
     `${JSON.stringify(opencodePackageJson, null, 2)}\n`,


### PR DESCRIPTION

OpenCode plugin subpath specifiers are still not universally installable, so this adds a publishable obsxa-opencode wrapper package and wires release automation to bump root first, sync wrapper version, bump wrapper changelog, and then finalize release. The tag-based release workflow now publishes both root and wrapper packages.

## Closes

Closes #18